### PR TITLE
 Change selector structure and add "astro" prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Here's a quick example. If you'd like to create a Display text styled in Astro t
 
 3. Go to Astro's [Typography page](https://magnetis.github.io/astro/#/docs-typography);
 
-4. See that the "Display" section guides you to create a `<p>` element with the `text--display` class;
+4. See that the "Display" section guides you to create a `<p>` element with a specific text display class;
 
 5. Replicate the instructions in your page file and make sure the correct styles have been applied;
 

--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -18,23 +18,23 @@ Use these for the main action in a section or screen. You should display only on
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="btn btn--uranus btn--medium">
+  <button className="astro__btn astro__btn--uranus astro__btn--medium">
     uranus
   </button>
 
-  <button className="btn btn--earth btn--medium">
+  <button className="astro__btn astro__btn--earth astro__btn--medium">
     earth
   </button>
 
-  <button className="btn btn--venus btn--medium">
+  <button className="astro__btn astro__btn--venus astro__btn--medium">
     venus
   </button>
 
-  <button className="btn btn--mars btn--medium">
+  <button className="astro__btn astro__btn--mars astro__btn--medium">
     mars
   </button>
   
-  <button className="btn btn--uranus btn--medium" disabled>
+  <button className="astro__btn astro__btn--uranus astro__btn--medium" disabled>
     disabled
   </button>
 </Playground>
@@ -48,23 +48,23 @@ Please note that there are color variations to the outline CSS classes. You also
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="btn btn--outline-uranus btn--medium">
+  <button className="astro__btn astro__btn--outline-uranus astro__btn--medium">
     outline uranus
   </button>
 
-  <button className="btn btn--outline-earth btn--medium">
+  <button className="astro__btn astro__btn--outline-earth astro__btn--medium">
     outline earth
   </button>
 
-  <button className="btn btn--outline-venus btn--medium">
+  <button className="astro__btn astro__btn--outline-venus astro__btn--medium">
     outline venus
   </button>
 
-  <button className="btn btn--outline-mars btn--medium">
+  <button className="astro__btn astro__btn--outline-mars astro__btn--medium">
     outline mars
   </button>
  
-  <button className="btn btn--outline-venus btn--medium" disabled>
+  <button className="astro__btn astro__btn--outline-venus astro__btn--medium" disabled>
     outline disabled
   </button>
 </Playground>
@@ -78,23 +78,23 @@ Aside from using the ghost button CSS class, you also need to specify size and c
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="btn btn--ghost-uranus btn--medium">
+  <button className="astro__btn astro__btn--ghost-uranus astro__btn--medium">
     ghost uranus
   </button>
 
-  <button className="btn btn--ghost-earth btn--medium">
+  <button className="astro__btn astro__btn--ghost-earth astro__btn--medium">
     ghost earth
   </button>
 
-  <button className="btn btn--ghost-venus btn--medium">
+  <button className="astro__btn astro__btn--ghost-venus astro__btn--medium">
     ghost venus
   </button>
 
-  <button className="btn btn--ghost-mars btn--medium">
+  <button className="astro__btn astro__btn--ghost-mars astro__btn--medium">
     ghost mars
   </button>
  
-  <button className="btn btn--ghost-venus btn--medium" disabled>
+  <button className="astro__btn astro__btn--ghost-venus astro__btn--medium" disabled>
     ghost disabled
   </button>
 </Playground>
@@ -104,39 +104,39 @@ Mouseover and click to view `:hover` and `:active` states.
 Buttons can have different sizes, also by changing their CSS size class.
 
 <Playground>
-  <button className="btn btn--uranus btn--small">
+  <button className="astro__btn astro__btn--uranus astro__btn--small">
     small
   </button>
  
-  <button className="btn btn--uranus btn--medium">
+  <button className="astro__btn astro__btn--uranus astro__btn--medium">
     medium
   </button>
 
-  <button className="btn btn--uranus btn--large">
+  <button className="astro__btn astro__btn--uranus astro__btn--large">
     large
   </button>
 </Playground>
 
 <Playground>
-  <button className="btn btn--outline-uranus btn--small">
+  <button className="astro__btn astro__btn--outline-uranus astro__btn--small">
     outline small
   </button>
-  <button className="btn btn--outline-uranus btn--medium">
+  <button className="astro__btn astro__btn--outline-uranus astro__btn--medium">
     outline medium
   </button>
-  <button className="btn btn--outline-uranus btn--large">
+  <button className="astro__btn astro__btn--outline-uranus astro__btn--large">
     outline large
   </button>
 </Playground>
 
 <Playground>
-  <button className="btn btn--ghost-uranus btn--small">
+  <button className="astro__btn astro__btn--ghost-uranus astro__btn--small">
     ghost small
   </button>
-  <button className="btn btn--ghost-uranus btn--medium">
+  <button className="astro__btn astro__btn--ghost-uranus astro__btn--medium">
     ghost medium
   </button>
-  <button className="btn btn--ghost-uranus btn--large">
+  <button className="astro__btn astro__btn--ghost-uranus astro__btn--large">
     ghost large
   </button>
 </Playground>
@@ -150,7 +150,7 @@ If you're looking for buttons in `<a>` tags, see "buttons in `<a>` elements" bel
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <a>inline link</a>
+  <a className="astro__link">inline link</a>
 </Playground>
 
 ## buttons in `<a>` elements
@@ -162,10 +162,10 @@ Although button classes are designed for `<button>` elements, you may also use t
 If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
 
 <Playground>
-  <a className="btn btn--uranus btn--medium">
+  <a className="astro__btn astro__btn--uranus astro__btn--medium">
     link button
   </a>
-  <a className="btn btn--uranus btn--medium disabled">
+  <a className="astro__btn astro__btn--uranus astro__btn--medium disabled">
     link button disabled
   </a>
 </Playground>

--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -18,23 +18,23 @@ Use these for the main action in a section or screen. You should display only on
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="astro__btn astro__btn--uranus astro__btn--medium">
+  <button className="a-btn a-btn--uranus a-btn--medium">
     uranus
   </button>
 
-  <button className="astro__btn astro__btn--earth astro__btn--medium">
+  <button className="a-btn a-btn--earth a-btn--medium">
     earth
   </button>
 
-  <button className="astro__btn astro__btn--venus astro__btn--medium">
+  <button className="a-btn a-btn--venus a-btn--medium">
     venus
   </button>
 
-  <button className="astro__btn astro__btn--mars astro__btn--medium">
+  <button className="a-btn a-btn--mars a-btn--medium">
     mars
   </button>
   
-  <button className="astro__btn astro__btn--uranus astro__btn--medium" disabled>
+  <button className="a-btn a-btn--uranus a-btn--medium" disabled>
     disabled
   </button>
 </Playground>
@@ -48,23 +48,23 @@ Please note that there are color variations to the outline CSS classes. You also
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="astro__btn astro__btn--outline-uranus astro__btn--medium">
+  <button className="a-btn a-btn--outline-uranus a-btn--medium">
     outline uranus
   </button>
 
-  <button className="astro__btn astro__btn--outline-earth astro__btn--medium">
+  <button className="a-btn a-btn--outline-earth a-btn--medium">
     outline earth
   </button>
 
-  <button className="astro__btn astro__btn--outline-venus astro__btn--medium">
+  <button className="a-btn a-btn--outline-venus a-btn--medium">
     outline venus
   </button>
 
-  <button className="astro__btn astro__btn--outline-mars astro__btn--medium">
+  <button className="a-btn a-btn--outline-mars a-btn--medium">
     outline mars
   </button>
  
-  <button className="astro__btn astro__btn--outline-venus astro__btn--medium" disabled>
+  <button className="a-btn a-btn--outline-venus a-btn--medium" disabled>
     outline disabled
   </button>
 </Playground>
@@ -78,23 +78,23 @@ Aside from using the ghost button CSS class, you also need to specify size and c
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="astro__btn astro__btn--ghost-uranus astro__btn--medium">
+  <button className="a-btn a-btn--ghost-uranus a-btn--medium">
     ghost uranus
   </button>
 
-  <button className="astro__btn astro__btn--ghost-earth astro__btn--medium">
+  <button className="a-btn a-btn--ghost-earth a-btn--medium">
     ghost earth
   </button>
 
-  <button className="astro__btn astro__btn--ghost-venus astro__btn--medium">
+  <button className="a-btn a-btn--ghost-venus a-btn--medium">
     ghost venus
   </button>
 
-  <button className="astro__btn astro__btn--ghost-mars astro__btn--medium">
+  <button className="a-btn a-btn--ghost-mars a-btn--medium">
     ghost mars
   </button>
  
-  <button className="astro__btn astro__btn--ghost-venus astro__btn--medium" disabled>
+  <button className="a-btn a-btn--ghost-venus a-btn--medium" disabled>
     ghost disabled
   </button>
 </Playground>
@@ -104,39 +104,39 @@ Mouseover and click to view `:hover` and `:active` states.
 Buttons can have different sizes, also by changing their CSS size class.
 
 <Playground>
-  <button className="astro__btn astro__btn--uranus astro__btn--small">
+  <button className="a-btn a-btn--uranus a-btn--small">
     small
   </button>
  
-  <button className="astro__btn astro__btn--uranus astro__btn--medium">
+  <button className="a-btn a-btn--uranus a-btn--medium">
     medium
   </button>
 
-  <button className="astro__btn astro__btn--uranus astro__btn--large">
+  <button className="a-btn a-btn--uranus a-btn--large">
     large
   </button>
 </Playground>
 
 <Playground>
-  <button className="astro__btn astro__btn--outline-uranus astro__btn--small">
+  <button className="a-btn a-btn--outline-uranus a-btn--small">
     outline small
   </button>
-  <button className="astro__btn astro__btn--outline-uranus astro__btn--medium">
+  <button className="a-btn a-btn--outline-uranus a-btn--medium">
     outline medium
   </button>
-  <button className="astro__btn astro__btn--outline-uranus astro__btn--large">
+  <button className="a-btn a-btn--outline-uranus a-btn--large">
     outline large
   </button>
 </Playground>
 
 <Playground>
-  <button className="astro__btn astro__btn--ghost-uranus astro__btn--small">
+  <button className="a-btn a-btn--ghost-uranus a-btn--small">
     ghost small
   </button>
-  <button className="astro__btn astro__btn--ghost-uranus astro__btn--medium">
+  <button className="a-btn a-btn--ghost-uranus a-btn--medium">
     ghost medium
   </button>
-  <button className="astro__btn astro__btn--ghost-uranus astro__btn--large">
+  <button className="a-btn a-btn--ghost-uranus a-btn--large">
     ghost large
   </button>
 </Playground>
@@ -150,7 +150,7 @@ If you're looking for buttons in `<a>` tags, see "buttons in `<a>` elements" bel
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <a className="astro__link">inline link</a>
+  <a className="a-link">inline link</a>
 </Playground>
 
 ## buttons in `<a>` elements
@@ -162,10 +162,10 @@ Although button classes are designed for `<button>` elements, you may also use t
 If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
 
 <Playground>
-  <a className="astro__btn astro__btn--uranus astro__btn--medium">
+  <a className="a-btn a-btn--uranus a-btn--medium">
     link button
   </a>
-  <a className="astro__btn astro__btn--uranus astro__btn--medium disabled">
+  <a className="a-btn a-btn--uranus a-btn--medium disabled">
     link button disabled
   </a>
 </Playground>

--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -157,7 +157,7 @@ Mouseover and click to view `:hover` and `:active` states.
 
 Although button classes are designed for `<button>` elements, you may also use them with `<a>` elements when semantically recommended. Note that some browsers may render them slightly differently. 
 
-`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add a `disabled` class like the example below.
+`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `a-btn--disabled` class like the example below.
 
 If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
 
@@ -165,7 +165,7 @@ If your `<a>` button triggers in-page functionalities instead of linking (to oth
   <a className="a-btn a-btn--uranus a-btn--medium">
     link button
   </a>
-  <a className="a-btn a-btn--uranus a-btn--medium disabled">
+  <a className="a-btn a-btn--uranus a-btn--medium a-btn--disabled">
     link button disabled
   </a>
 </Playground>

--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -14,22 +14,22 @@ Checkboxes are used when a user might select multiple options from a list, or wh
 Mouseover to view `:hover` state.
 
 <Playground>
-  <div className="checkbox">
+  <div className="astro__checkbox">
     <input type="checkbox" id="checkbox1" />
     <label htmlFor="checkbox1">Checkbox</label>
   </div>
 
-  <div className="checkbox">
+  <div className="astro__checkbox">
     <input type="checkbox" id="checkbox2" checked />
     <label htmlFor="checkbox2">Checked</label>
   </div>
 
-  <div className="checkbox checkbox--indeterminate">
+  <div className="astro__checkbox astro__checkbox--indeterminate">
     <input type="checkbox" id="checkbox3" checked />
     <label htmlFor="checkbox3">Indeterminate</label>
   </div>
 
-  <div className="checkbox checkbox--disabled">
+  <div className="astro__checkbox astro__checkbox--disabled">
     <input type="checkbox" id="checkbox4" disabled />
     <label htmlFor="checkbox4">Disabled</label>
   </div>

--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -14,22 +14,22 @@ Checkboxes are used when a user might select multiple options from a list, or wh
 Mouseover to view `:hover` state.
 
 <Playground>
-  <div className="astro__checkbox">
+  <div className="a-checkbox">
     <input type="checkbox" id="checkbox1" />
     <label htmlFor="checkbox1">Checkbox</label>
   </div>
 
-  <div className="astro__checkbox">
+  <div className="a-checkbox">
     <input type="checkbox" id="checkbox2" checked />
     <label htmlFor="checkbox2">Checked</label>
   </div>
 
-  <div className="astro__checkbox astro__checkbox--indeterminate">
+  <div className="a-checkbox a-checkbox--indeterminate">
     <input type="checkbox" id="checkbox3" checked />
     <label htmlFor="checkbox3">Indeterminate</label>
   </div>
 
-  <div className="astro__checkbox astro__checkbox--disabled">
+  <div className="a-checkbox a-checkbox--disabled">
     <input type="checkbox" id="checkbox4" disabled />
     <label htmlFor="checkbox4">Disabled</label>
   </div>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -96,7 +96,7 @@ import { Fragment } from 'react'
 ```jsx
   import '../src/index.css';
 
-  <button className="astro__btn astro__btn--uranus astro__btn--medium">
+  <button className="a-btn a-btn--uranus a-btn--medium">
     primary
   </button>
 ```

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -96,7 +96,7 @@ import { Fragment } from 'react'
 ```jsx
   import '../src/index.css';
 
-  <button className="btn btn--uranus btn--medium">
+  <button className="astro__btn astro__btn--uranus astro__btn--medium">
     primary
   </button>
 ```

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -14,9 +14,9 @@ Astro has a purposeful set of typographic styles that provide content organizati
 Poppins is our primary font, used in the whole product’s interfaces for interactive components, contextual titles and texts. Poppins provides good legibility in small and large sizes.
 
 <Playground>
-  <p className="astro__text--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
-  <p className="astro__text--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
-  <p className="astro__text--large">0 1 2 3 4 5 6 7 8 9</p>
+  <p className="a-text--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+  <p className="a-text--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+  <p className="a-text--large">0 1 2 3 4 5 6 7 8 9</p>
 </Playground>
 
 ### sizes
@@ -24,19 +24,19 @@ Poppins is our primary font, used in the whole product’s interfaces for intera
 You may apply CSS classes from the examples below to any HTML elements, according to your semantic needs.
 
 <Playground>
-  <p className="astro__text--display">display. huge</p>
+  <p className="a-text--display">display. huge</p>
 </Playground>
 
 <Playground>
-  <p className="astro__title--large">title. large</p>
-  <p className="astro__title--medium">title. medium</p>
-  <p className="astro__title--small">title. small</p>
+  <p className="a-title--large">title. large</p>
+  <p className="a-title--medium">title. medium</p>
+  <p className="a-title--small">title. small</p>
 </Playground>
 
 <Playground>
-  <p className="astro__text--large">text. large</p>
-  <p className="astro__text--medium">text. medium</p>
-  <p className="astro__text--small">text. small</p>
+  <p className="a-text--large">text. large</p>
+  <p className="a-text--medium">text. medium</p>
+  <p className="a-text--small">text. small</p>
 </Playground>
 
 ## Lato - [download](https://fonts.google.com/specimen/Lato?selection.family=Lato)
@@ -44,15 +44,15 @@ You may apply CSS classes from the examples below to any HTML elements, accordin
 Lato is our secondary font. Used in informative texts and components that demand smaller labels, Lato provides good and dynamic legibility, with a serious but friendly structure.
 
 <Playground>
-  <p className="astro__text--secondary--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
-  <p className="astro__text--secondary--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
-  <p className="astro__text--secondary--large">0 1 2 3 4 5 6 7 8 9</p>
+  <p className="a-text--secondary--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+  <p className="a-text--secondary--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+  <p className="a-text--secondary--large">0 1 2 3 4 5 6 7 8 9</p>
 </Playground>
 
 ### sizes
 
 <Playground>
-  <p className="astro__text--secondary--large">text. large</p>
-  <p className="astro__text--secondary--medium">text. medium</p>
-  <p className="astro__text--secondary--small">text. small</p>
+  <p className="a-text--secondary--large">text. large</p>
+  <p className="a-text--secondary--medium">text. medium</p>
+  <p className="a-text--secondary--small">text. small</p>
 </Playground>

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -44,15 +44,15 @@ You may apply CSS classes from the examples below to any HTML elements, accordin
 Lato is our secondary font. Used in informative texts and components that demand smaller labels, Lato provides good and dynamic legibility, with a serious but friendly structure.
 
 <Playground>
-  <p className="a-text--secondary--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
-  <p className="a-text--secondary--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
-  <p className="a-text--secondary--large">0 1 2 3 4 5 6 7 8 9</p>
+  <p className="a-text--secondary-large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+  <p className="a-text--secondary-large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+  <p className="a-text--secondary-large">0 1 2 3 4 5 6 7 8 9</p>
 </Playground>
 
 ### sizes
 
 <Playground>
-  <p className="a-text--secondary--large">text. large</p>
-  <p className="a-text--secondary--medium">text. medium</p>
-  <p className="a-text--secondary--small">text. small</p>
+  <p className="a-text--secondary-large">text. large</p>
+  <p className="a-text--secondary-medium">text. medium</p>
+  <p className="a-text--secondary-small">text. small</p>
 </Playground>

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -9,63 +9,50 @@ import { Playground } from 'docz'
 
 Astro has a purposeful set of typographic styles that provide content organization, hierarchy patterns and consistent information architecture which is essential for good understanding and a solid user experience.
 
-## typefaces
+## Poppins - [download](https://fonts.google.com/specimen/Poppins?selection.family=Poppins:500,600,700)
 
-### Poppins - [download](https://fonts.google.com/specimen/Poppins?selection.family=Poppins:300,400,500,700)
-
-Poppins is our primary font, used in the whole product’s interfaces for interactive components, contextual titles and texts.
+Poppins is our primary font, used in the whole product’s interfaces for interactive components, contextual titles and texts. Poppins provides good legibility in small and large sizes.
 
 <Playground>
-  <p className="text--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
-  <p className="text--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
-  <p className="text--large">0 1 2 3 4 5 6 7 8 9</p>
+  <p className="astro__text--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+  <p className="astro__text--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+  <p className="astro__text--large">0 1 2 3 4 5 6 7 8 9</p>
 </Playground>
 
-#### display
+### sizes
 
-Displays are usually `<p>` HTML elements. They should be used in special cases when a huge and highlighted text is needed, mostly in graphic pieces and components of the product or outer pages and vehicles.
+You may apply CSS classes from the examples below to any HTML elements, according to your semantic needs.
 
 <Playground>
-  <p className="text--display">disp. astro typography</p>
+  <p className="astro__text--display">display. huge</p>
 </Playground>
 
-#### headings
-
-Heading styles are set with `<h1>` to `<h4>` HTML elements, but you may also use `.h1` to `.h4` classes if you need to apply these styles to a different markup.
-
 <Playground>
-  <h1>h1. astro typography</h1>
-  <h2>h2. astro typography</h2>
-  <h3>h3. astro typography</h3>
-  <h4>h4. astro typography</h4>
+  <p className="astro__title--large">title. large</p>
+  <p className="astro__title--medium">title. medium</p>
+  <p className="astro__title--small">title. small</p>
 </Playground>
 
-#### paragraphs
-
-Paragraphs are set with `<p>` HTML elements. Default size is medium, so you'll only need CSS size classes for small and large sizes.
-
 <Playground>
-  <p className="text--large">p. astro typography</p>
-  <p>p. astro typography</p>
-  <p className="text--small">p. astro typography</p>
+  <p className="astro__text--large">text. large</p>
+  <p className="astro__text--medium">text. medium</p>
+  <p className="astro__text--small">text. small</p>
 </Playground>
 
-### Lato - [download](https://fonts.google.com/specimen/Lato?selection.family=Lato)
+## Lato - [download](https://fonts.google.com/specimen/Lato?selection.family=Lato)
 
-Lato is our secondary font, used only in paragraphs when maximum legibility is needed - especially in small texts. 
-
-Default size is medium, so you'll only need CSS size classes for small and large sizes.
+Lato is our secondary font. Used in informative texts and components that demand smaller labels, Lato provides good and dynamic legibility, with a serious but friendly structure.
 
 <Playground>
-  <p className="text--secondary">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
-  <p className="text--secondary">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
-  <p className="text--secondary">0 1 2 3 4 5 6 7 8 9</p>
+  <p className="astro__text--secondary--large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</p>
+  <p className="astro__text--secondary--large">a b c d e f g h i j k l m n o p q r s t u v w x y z</p>
+  <p className="astro__text--secondary--large">0 1 2 3 4 5 6 7 8 9</p>
 </Playground>
 
-#### paragraphs
+### sizes
 
 <Playground>
-  <p className="text--secondary text--large">p. astro typography</p>
-  <p className="text--secondary">p. astro typography</p>
-  <p className="text--secondary text--small">p. astro typography</p>
+  <p className="astro__text--secondary--large">text. large</p>
+  <p className="astro__text--secondary--medium">text. medium</p>
+  <p className="astro__text--secondary--small">text. small</p>
 </Playground>

--- a/public/docz.html
+++ b/public/docz.html
@@ -5,7 +5,7 @@
     <meta name="description" content="{{ description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link href="https://fonts.googleapis.com/css?family=Poppins:400,500,600,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Poppins:500,600,700" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet"> 
     <title>{{ title }}</title>
     {{ head }}

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1,9 +1,6 @@
-body {
-  font-family: 'Poppins', sans-serif;
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 1.5;
-  color: var(--color-moon-900);
+.astro__body { /* styles replicated in typography to allow isolation */
+  font: var(--font-primary);
+  color: var(--font-color);
   text-rendering: optimizeLegibility;
 }
 
@@ -23,51 +20,27 @@ img {
   height: auto;
 }
 
-h1,
-.h1 {
-  font-size: 48px;
-  font-weight: 700;
+li,
+ul {
+  list-style: none;
+  padding: 0;
 }
 
-h2,
-.h2 {
-  font-size: 40px;
-  font-weight: 700;
-}
-
-h3,
-.h3 {
-  font-size: 32px;
-  font-weight: 600;
-}
-
-h4,
-.h4 {
-  font-size: 24px;
-  font-weight: 600;
-}
-
-a {
+.astro__link {
   color: var(--color-uranus-700);
   text-decoration: underline;
   cursor: pointer;
   word-wrap: break-word;
 }
 
-a:hover {
+.astro__link:hover {
   color: var(--color-uranus-500);
 }
 
-a:active {
+.astro__link:active {
   color: var(--color-uranus-800);
 }
 
-a.btn {
+.astro__link.astro__btn {
   text-decoration: none;
-}
-
-li,
-ul {
-  list-style: none;
-  padding: 0;
 }

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1,4 +1,4 @@
-.astro__body { /* styles replicated in typography to allow isolation */
+.a-body { /* styles replicated in typography to allow isolation */
   font: var(--font-primary);
   color: var(--font-color);
   text-rendering: optimizeLegibility;
@@ -26,21 +26,21 @@ ul {
   padding: 0;
 }
 
-.astro__link {
+.a-link {
   color: var(--color-uranus-700);
   text-decoration: underline;
   cursor: pointer;
   word-wrap: break-word;
 }
 
-.astro__link:hover {
+.a-link:hover {
   color: var(--color-uranus-500);
 }
 
-.astro__link:active {
+.a-link:active {
   color: var(--color-uranus-800);
 }
 
-.astro__link.astro__btn {
+.a-link.a-btn {
   text-decoration: none;
 }

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -1,6 +1,6 @@
 /* Base button styles */
 
-.btn {
+.astro__btn {
   cursor: pointer;
   display: inline-block;
   white-space: nowrap;
@@ -9,8 +9,8 @@
   overflow: hidden;
 }
 
-.btn:disabled,
-.btn.disabled {
+.astro__btn:disabled,
+.astro__btn.disabled {
   cursor: not-allowed;
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
@@ -19,87 +19,87 @@
 
 /* Button color modifiers */
 
-.btn--uranus {
+.astro__btn--uranus {
   background-color: var(--color-uranus-500);
   border: 2px solid var(--color-uranus-500);
   color: var(--color-space-100);
 }
 
-.btn--uranus:hover:not(:disabled) {
+.astro__btn--uranus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-400);
   border-color: var(--color-uranus-400);
 }
 
-.btn--uranus:active:not(:disabled) {
+.astro__btn--uranus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-600);
   border-color: var(--color-uranus-600);
 }
 
-.btn--venus {
+.astro__btn--venus {
   background-color: var(--color-venus-400);
   border: 2px solid var(--color-venus-400);
   color: var(--color-space-100);
 }
 
-.btn--venus:hover:not(:disabled) {
+.astro__btn--venus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-300);
   border-color: var(--color-venus-300);
 }
 
-.btn--venus:active:not(:disabled) {
+.astro__btn--venus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-500);
   border-color: var(--color-venus-500);
 }
 
-.btn--mars {
+.astro__btn--mars {
   background-color: var(--color-mars-500);
   border: 2px solid var(--color-mars-500);
   color: var(--color-space-100);
 }
 
-.btn--mars:hover:not(:disabled) {
+.astro__btn--mars:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-400);
   border-color: var(--color-mars-400);
 }
 
-.btn--mars:active:not(:disabled) {
+.astro__btn--mars:active:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-600);
   border-color: var(--color-mars-600);
 }
 
-.btn--earth {
+.astro__btn--earth {
   background-color: var(--color-earth-400);
   border: 2px solid var(--color-earth-400);
   color: var(--color-moon-900);
 }
 
-.btn--earth:hover:not(:disabled) {
+.astro__btn--earth:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-300);
   border-color: var(--color-earth-300);
 }
 
-.btn--earth:active:not(:disabled) {
+.astro__btn--earth:active:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-500);
   border-color: var(--color-earth-500);
 }
 
 /* Button size modifiers */
 
-.btn--small {
+.astro__btn--small {
   padding: 5px 37px;
   border-radius: 16px;
   font-size: 12px;
   line-height: 18px;
 }
 
-.btn--medium {
+.astro__btn--medium {
   padding: 8px 38px;
   border-radius: 24px;
   font-size: 16px;
   line-height: 28px;
 }
 
-.btn--large {
+.astro__btn--large {
   padding: 12px 71px;
   border-radius: 31px;
   font-size: 24px;
@@ -108,73 +108,73 @@
 
 /* Outline button */
 
-.btn--outline-uranus {
+.astro__btn--outline-uranus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-uranus-500);
   color: var(--color-uranus-500);
 }
 
-.btn--outline-uranus:hover:not(:disabled) {
+.astro__btn--outline-uranus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-400);
   border-color: var(--color-uranus-400);
   color: var(--color-space-100);
 }
 
-.btn--outline-uranus:active:not(:disabled) {
+.astro__btn--outline-uranus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-600);
   border-color: var(--color-uranus-600);
   color: var(--color-space-100);
 }
 
-.btn--outline-venus {
+.astro__btn--outline-venus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-venus-400);
   color: var(--color-venus-400);
 }
 
-.btn--outline-venus:hover:not(:disabled) {
+.astro__btn--outline-venus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-300);
   border-color: var(--color-venus-300);
   color: var(--color-space-100);
 }
 
-.btn--outline-venus:active:not(:disabled) {
+.astro__btn--outline-venus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-500);
   border-color: var(--color-venus-500);
   color: var(--color-space-100);
 }
 
-.btn--outline-earth {
+.astro__btn--outline-earth {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-earth-600);
   color: var(--color-earth-600);
 }
 
-.btn--outline-earth:hover:not(:disabled) {
+.astro__btn--outline-earth:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-300);
   border-color: var(--color-earth-300);
   color: var(--color-moon-900);
 }
 
-.btn--outline-earth:active:not(:disabled) {
+.astro__btn--outline-earth:active:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-500);
   border-color: var(--color-earth-500);
   color: var(--color-moon-900);
 }
 
-.btn--outline-mars {
+.astro__btn--outline-mars {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-mars-500);
   color: var(--color-mars-500);
 }
 
-.btn--outline-mars:hover:not(:disabled) {
+.astro__btn--outline-mars:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-400);
   border-color: var(--color-mars-400);
   color: var(--color-space-100);
 }
 
-.btn--outline-mars:active:not(:disabled) {
+.astro__btn--outline-mars:active:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-600);
   border-color: var(--color-mars-600);
   color: var(--color-space-100);
@@ -182,14 +182,14 @@
 
 /* stylelint-disable no-descending-specificity */
 
-.btn--outline-uranus:disabled,
-.btn--outline-venus:disabled,
-.btn--outline-earth:disabled,
-.btn--outline-mars:disabled,
-.btn--outline-uranus.disabled,
-.btn--outline-venus.disabled,
-.btn--outline-earth.disabled,
-.btn--outline-mars.disabled {
+.astro__btn--outline-uranus:disabled,
+.astro__btn--outline-venus:disabled,
+.astro__btn--outline-earth:disabled,
+.astro__btn--outline-mars:disabled,
+.astro__btn--outline-uranus.disabled,
+.astro__btn--outline-venus.disabled,
+.astro__btn--outline-earth.disabled,
+.astro__btn--outline-mars.disabled {
   cursor: not-allowed;
   background-color: var(--color-space-100);
   border-color: var(--color-moon-200);
@@ -200,73 +200,73 @@
 
 /* Ghost button */
 
-.btn--ghost-uranus {
+.astro__btn--ghost-uranus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-uranus-500);
 }
 
-.btn--ghost-uranus:hover:not(:disabled) {
+.astro__btn--ghost-uranus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-uranus-400);
 }
 
-.btn--ghost-uranus:active:not(:disabled) {
+.astro__btn--ghost-uranus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-uranus-600);
 }
 
-.btn--ghost-venus {
+.astro__btn--ghost-venus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-venus-400);
 }
 
-.btn--ghost-venus:hover:not(:disabled) {
+.astro__btn--ghost-venus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-venus-300);
 }
 
-.btn--ghost-venus:active:not(:disabled) {
+.astro__btn--ghost-venus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-venus-500);
 }
 
-.btn--ghost-earth {
+.astro__btn--ghost-earth {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-earth-600);
 }
 
-.btn--ghost-earth:hover:not(:disabled) {
+.astro__btn--ghost-earth:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-earth-300);
 }
 
-.btn--ghost-earth:active:not(:disabled) {
+.astro__btn--ghost-earth:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-earth-800);
 }
 
-.btn--ghost-mars {
+.astro__btn--ghost-mars {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-mars-500);
 }
 
-.btn--ghost-mars:hover:not(:disabled) {
+.astro__btn--ghost-mars:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-mars-400);
 }
 
-.btn--ghost-mars:active:not(:disabled) {
+.astro__btn--ghost-mars:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-mars-600);
@@ -274,14 +274,14 @@
 
 /* stylelint-disable no-descending-specificity */
 
-.btn--ghost-uranus:disabled,
-.btn--ghost-venus:disabled,
-.btn--ghost-earth:disabled,
-.btn--ghost-mars:disabled,
-.btn--ghost-uranus.disabled,
-.btn--ghost-venus.disabled,
-.btn--ghost-earth.disabled,
-.btn--ghost-mars.disabled {
+.astro__btn--ghost-uranus:disabled,
+.astro__btn--ghost-venus:disabled,
+.astro__btn--ghost-earth:disabled,
+.astro__btn--ghost-mars:disabled,
+.astro__btn--ghost-uranus.disabled,
+.astro__btn--ghost-venus.disabled,
+.astro__btn--ghost-earth.disabled,
+.astro__btn--ghost-mars.disabled {
   cursor: not-allowed;
   background-color: var(--color-space-100);
   border-color: var(--color-space-100);

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -10,7 +10,7 @@
 }
 
 .a-btn:disabled,
-.a-btn.disabled {
+.a-btn.a-btn--disabled {
   cursor: not-allowed;
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
@@ -25,12 +25,12 @@
   color: var(--color-space-100);
 }
 
-.a-btn--uranus:hover:not(:disabled):not(.disabled) {
+.a-btn--uranus:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-uranus-400);
   border-color: var(--color-uranus-400);
 }
 
-.a-btn--uranus:active:not(:disabled):not(.disabled) {
+.a-btn--uranus:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-uranus-600);
   border-color: var(--color-uranus-600);
 }
@@ -41,12 +41,12 @@
   color: var(--color-space-100);
 }
 
-.a-btn--venus:hover:not(:disabled):not(.disabled) {
+.a-btn--venus:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-venus-300);
   border-color: var(--color-venus-300);
 }
 
-.a-btn--venus:active:not(:disabled):not(.disabled) {
+.a-btn--venus:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-venus-500);
   border-color: var(--color-venus-500);
 }
@@ -57,12 +57,12 @@
   color: var(--color-space-100);
 }
 
-.a-btn--mars:hover:not(:disabled):not(.disabled) {
+.a-btn--mars:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-mars-400);
   border-color: var(--color-mars-400);
 }
 
-.a-btn--mars:active:not(:disabled):not(.disabled) {
+.a-btn--mars:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-mars-600);
   border-color: var(--color-mars-600);
 }
@@ -73,12 +73,12 @@
   color: var(--color-moon-900);
 }
 
-.a-btn--earth:hover:not(:disabled):not(.disabled) {
+.a-btn--earth:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-earth-300);
   border-color: var(--color-earth-300);
 }
 
-.a-btn--earth:active:not(:disabled):not(.disabled) {
+.a-btn--earth:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-earth-500);
   border-color: var(--color-earth-500);
 }
@@ -114,13 +114,13 @@
   color: var(--color-uranus-500);
 }
 
-.a-btn--outline-uranus:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-uranus:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-uranus-400);
   border-color: var(--color-uranus-400);
   color: var(--color-space-100);
 }
 
-.a-btn--outline-uranus:active:not(:disabled):not(.disabled) {
+.a-btn--outline-uranus:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-uranus-600);
   border-color: var(--color-uranus-600);
   color: var(--color-space-100);
@@ -132,13 +132,13 @@
   color: var(--color-venus-400);
 }
 
-.a-btn--outline-venus:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-venus:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-venus-300);
   border-color: var(--color-venus-300);
   color: var(--color-space-100);
 }
 
-.a-btn--outline-venus:active:not(:disabled):not(.disabled) {
+.a-btn--outline-venus:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-venus-500);
   border-color: var(--color-venus-500);
   color: var(--color-space-100);
@@ -150,13 +150,13 @@
   color: var(--color-earth-600);
 }
 
-.a-btn--outline-earth:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-earth:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-earth-300);
   border-color: var(--color-earth-300);
   color: var(--color-moon-900);
 }
 
-.a-btn--outline-earth:active:not(:disabled):not(.disabled) {
+.a-btn--outline-earth:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-earth-500);
   border-color: var(--color-earth-500);
   color: var(--color-moon-900);
@@ -168,13 +168,13 @@
   color: var(--color-mars-500);
 }
 
-.a-btn--outline-mars:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-mars:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-mars-400);
   border-color: var(--color-mars-400);
   color: var(--color-space-100);
 }
 
-.a-btn--outline-mars:active:not(:disabled):not(.disabled) {
+.a-btn--outline-mars:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-mars-600);
   border-color: var(--color-mars-600);
   color: var(--color-space-100);
@@ -186,10 +186,10 @@
 .a-btn--outline-venus:disabled,
 .a-btn--outline-earth:disabled,
 .a-btn--outline-mars:disabled,
-.a-btn--outline-uranus.disabled,
-.a-btn--outline-venus.disabled,
-.a-btn--outline-earth.disabled,
-.a-btn--outline-mars.disabled {
+.a-btn--outline-uranus.a-btn--disabled,
+.a-btn--outline-venus.a-btn--disabled,
+.a-btn--outline-earth.a-btn--disabled,
+.a-btn--outline-mars.a-btn--disabled {
   cursor: not-allowed;
   background-color: var(--color-space-100);
   border-color: var(--color-moon-200);
@@ -206,13 +206,13 @@
   color: var(--color-uranus-500);
 }
 
-.a-btn--ghost-uranus:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-uranus:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-uranus-400);
 }
 
-.a-btn--ghost-uranus:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-uranus:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-uranus-600);
@@ -224,13 +224,13 @@
   color: var(--color-venus-400);
 }
 
-.a-btn--ghost-venus:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-venus:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-venus-300);
 }
 
-.a-btn--ghost-venus:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-venus:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-venus-500);
@@ -242,13 +242,13 @@
   color: var(--color-earth-600);
 }
 
-.a-btn--ghost-earth:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-earth:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-earth-300);
 }
 
-.a-btn--ghost-earth:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-earth:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-earth-800);
@@ -260,13 +260,13 @@
   color: var(--color-mars-500);
 }
 
-.a-btn--ghost-mars:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-mars:hover:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-mars-400);
 }
 
-.a-btn--ghost-mars:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-mars:active:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-mars-600);
@@ -278,10 +278,10 @@
 .a-btn--ghost-venus:disabled,
 .a-btn--ghost-earth:disabled,
 .a-btn--ghost-mars:disabled,
-.a-btn--ghost-uranus.disabled,
-.a-btn--ghost-venus.disabled,
-.a-btn--ghost-earth.disabled,
-.a-btn--ghost-mars.disabled {
+.a-btn--ghost-uranus.a-btn--disabled,
+.a-btn--ghost-venus.a-btn--disabled,
+.a-btn--ghost-earth.a-btn--disabled,
+.a-btn--ghost-mars.a-btn--disabled {
   cursor: not-allowed;
   background-color: var(--color-space-100);
   border-color: var(--color-space-100);

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -1,6 +1,6 @@
 /* Base button styles */
 
-.astro__btn {
+.a-btn {
   cursor: pointer;
   display: inline-block;
   white-space: nowrap;
@@ -9,8 +9,8 @@
   overflow: hidden;
 }
 
-.astro__btn:disabled,
-.astro__btn.disabled {
+.a-btn:disabled,
+.a-btn.disabled {
   cursor: not-allowed;
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
@@ -19,87 +19,87 @@
 
 /* Button color modifiers */
 
-.astro__btn--uranus {
+.a-btn--uranus {
   background-color: var(--color-uranus-500);
   border: 2px solid var(--color-uranus-500);
   color: var(--color-space-100);
 }
 
-.astro__btn--uranus:hover:not(:disabled):not(.disabled) {
+.a-btn--uranus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-400);
   border-color: var(--color-uranus-400);
 }
 
-.astro__btn--uranus:active:not(:disabled):not(.disabled) {
+.a-btn--uranus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-600);
   border-color: var(--color-uranus-600);
 }
 
-.astro__btn--venus {
+.a-btn--venus {
   background-color: var(--color-venus-400);
   border: 2px solid var(--color-venus-400);
   color: var(--color-space-100);
 }
 
-.astro__btn--venus:hover:not(:disabled):not(.disabled) {
+.a-btn--venus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-300);
   border-color: var(--color-venus-300);
 }
 
-.astro__btn--venus:active:not(:disabled):not(.disabled) {
+.a-btn--venus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-500);
   border-color: var(--color-venus-500);
 }
 
-.astro__btn--mars {
+.a-btn--mars {
   background-color: var(--color-mars-500);
   border: 2px solid var(--color-mars-500);
   color: var(--color-space-100);
 }
 
-.astro__btn--mars:hover:not(:disabled):not(.disabled) {
+.a-btn--mars:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-400);
   border-color: var(--color-mars-400);
 }
 
-.astro__btn--mars:active:not(:disabled):not(.disabled) {
+.a-btn--mars:active:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-600);
   border-color: var(--color-mars-600);
 }
 
-.astro__btn--earth {
+.a-btn--earth {
   background-color: var(--color-earth-400);
   border: 2px solid var(--color-earth-400);
   color: var(--color-moon-900);
 }
 
-.astro__btn--earth:hover:not(:disabled):not(.disabled) {
+.a-btn--earth:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-300);
   border-color: var(--color-earth-300);
 }
 
-.astro__btn--earth:active:not(:disabled):not(.disabled) {
+.a-btn--earth:active:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-500);
   border-color: var(--color-earth-500);
 }
 
 /* Button size modifiers */
 
-.astro__btn--small {
+.a-btn--small {
   padding: 5px 37px;
   border-radius: 16px;
   font-size: 12px;
   line-height: 18px;
 }
 
-.astro__btn--medium {
+.a-btn--medium {
   padding: 8px 38px;
   border-radius: 24px;
   font-size: 16px;
   line-height: 28px;
 }
 
-.astro__btn--large {
+.a-btn--large {
   padding: 12px 71px;
   border-radius: 31px;
   font-size: 24px;
@@ -108,73 +108,73 @@
 
 /* Outline button */
 
-.astro__btn--outline-uranus {
+.a-btn--outline-uranus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-uranus-500);
   color: var(--color-uranus-500);
 }
 
-.astro__btn--outline-uranus:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-uranus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-400);
   border-color: var(--color-uranus-400);
   color: var(--color-space-100);
 }
 
-.astro__btn--outline-uranus:active:not(:disabled):not(.disabled) {
+.a-btn--outline-uranus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-uranus-600);
   border-color: var(--color-uranus-600);
   color: var(--color-space-100);
 }
 
-.astro__btn--outline-venus {
+.a-btn--outline-venus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-venus-400);
   color: var(--color-venus-400);
 }
 
-.astro__btn--outline-venus:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-venus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-300);
   border-color: var(--color-venus-300);
   color: var(--color-space-100);
 }
 
-.astro__btn--outline-venus:active:not(:disabled):not(.disabled) {
+.a-btn--outline-venus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-venus-500);
   border-color: var(--color-venus-500);
   color: var(--color-space-100);
 }
 
-.astro__btn--outline-earth {
+.a-btn--outline-earth {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-earth-600);
   color: var(--color-earth-600);
 }
 
-.astro__btn--outline-earth:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-earth:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-300);
   border-color: var(--color-earth-300);
   color: var(--color-moon-900);
 }
 
-.astro__btn--outline-earth:active:not(:disabled):not(.disabled) {
+.a-btn--outline-earth:active:not(:disabled):not(.disabled) {
   background-color: var(--color-earth-500);
   border-color: var(--color-earth-500);
   color: var(--color-moon-900);
 }
 
-.astro__btn--outline-mars {
+.a-btn--outline-mars {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-mars-500);
   color: var(--color-mars-500);
 }
 
-.astro__btn--outline-mars:hover:not(:disabled):not(.disabled) {
+.a-btn--outline-mars:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-400);
   border-color: var(--color-mars-400);
   color: var(--color-space-100);
 }
 
-.astro__btn--outline-mars:active:not(:disabled):not(.disabled) {
+.a-btn--outline-mars:active:not(:disabled):not(.disabled) {
   background-color: var(--color-mars-600);
   border-color: var(--color-mars-600);
   color: var(--color-space-100);
@@ -182,14 +182,14 @@
 
 /* stylelint-disable no-descending-specificity */
 
-.astro__btn--outline-uranus:disabled,
-.astro__btn--outline-venus:disabled,
-.astro__btn--outline-earth:disabled,
-.astro__btn--outline-mars:disabled,
-.astro__btn--outline-uranus.disabled,
-.astro__btn--outline-venus.disabled,
-.astro__btn--outline-earth.disabled,
-.astro__btn--outline-mars.disabled {
+.a-btn--outline-uranus:disabled,
+.a-btn--outline-venus:disabled,
+.a-btn--outline-earth:disabled,
+.a-btn--outline-mars:disabled,
+.a-btn--outline-uranus.disabled,
+.a-btn--outline-venus.disabled,
+.a-btn--outline-earth.disabled,
+.a-btn--outline-mars.disabled {
   cursor: not-allowed;
   background-color: var(--color-space-100);
   border-color: var(--color-moon-200);
@@ -200,73 +200,73 @@
 
 /* Ghost button */
 
-.astro__btn--ghost-uranus {
+.a-btn--ghost-uranus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-uranus-500);
 }
 
-.astro__btn--ghost-uranus:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-uranus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-uranus-400);
 }
 
-.astro__btn--ghost-uranus:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-uranus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-uranus-600);
 }
 
-.astro__btn--ghost-venus {
+.a-btn--ghost-venus {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-venus-400);
 }
 
-.astro__btn--ghost-venus:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-venus:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-venus-300);
 }
 
-.astro__btn--ghost-venus:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-venus:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-venus-500);
 }
 
-.astro__btn--ghost-earth {
+.a-btn--ghost-earth {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-earth-600);
 }
 
-.astro__btn--ghost-earth:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-earth:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-earth-300);
 }
 
-.astro__btn--ghost-earth:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-earth:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-earth-800);
 }
 
-.astro__btn--ghost-mars {
+.a-btn--ghost-mars {
   background-color: var(--color-space-100);
   border: 2px solid var(--color-space-100);
   color: var(--color-mars-500);
 }
 
-.astro__btn--ghost-mars:hover:not(:disabled):not(.disabled) {
+.a-btn--ghost-mars:hover:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-mars-400);
 }
 
-.astro__btn--ghost-mars:active:not(:disabled):not(.disabled) {
+.a-btn--ghost-mars:active:not(:disabled):not(.disabled) {
   background-color: var(--color-moon-200);
   border-color: var(--color-moon-200);
   color: var(--color-mars-600);
@@ -274,14 +274,14 @@
 
 /* stylelint-disable no-descending-specificity */
 
-.astro__btn--ghost-uranus:disabled,
-.astro__btn--ghost-venus:disabled,
-.astro__btn--ghost-earth:disabled,
-.astro__btn--ghost-mars:disabled,
-.astro__btn--ghost-uranus.disabled,
-.astro__btn--ghost-venus.disabled,
-.astro__btn--ghost-earth.disabled,
-.astro__btn--ghost-mars.disabled {
+.a-btn--ghost-uranus:disabled,
+.a-btn--ghost-venus:disabled,
+.a-btn--ghost-earth:disabled,
+.a-btn--ghost-mars:disabled,
+.a-btn--ghost-uranus.disabled,
+.a-btn--ghost-venus.disabled,
+.a-btn--ghost-earth.disabled,
+.a-btn--ghost-mars.disabled {
   cursor: not-allowed;
   background-color: var(--color-space-100);
   border-color: var(--color-space-100);

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -2,7 +2,7 @@
   opacity: 0;
 }
 
-.astro__checkbox--disabled {
+.astro__checkbox--disabled > label {
   cursor: not-allowed;
   opacity: 0.2;
 }

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -50,14 +50,6 @@
   border-left: 0;
 }
 
-.a-checkbox > input[type='checkbox'] + label::after {
-  content: none;
-}
-
-.a-checkbox > input[type='checkbox']:checked + label::after {
-  content: '';
-}
-
 .a-checkbox > input[type='checkbox']:checked + label::before {
   border-color: var(--color-uranus-500);
   background-color: var(--color-uranus-500);

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -1,13 +1,13 @@
-.astro__checkbox > input[type='checkbox'] {
+.a-checkbox > input[type='checkbox'] {
   opacity: 0;
 }
 
-.astro__checkbox--disabled > label {
+.a-checkbox--disabled > label {
   cursor: not-allowed;
   opacity: 0.2;
 }
 
-.astro__checkbox > label {
+.a-checkbox > label {
   position: relative;
   display: inline-block;
   padding-left: 24px;
@@ -15,14 +15,14 @@
   font-size: 16px;
 }
 
-.astro__checkbox > label::before,
-.astro__checkbox > label::after {
+.a-checkbox > label::before,
+.a-checkbox > label::after {
   position: absolute;
   display: inline-block;
   content: '';
 }
 
-.astro__checkbox > label::before {
+.a-checkbox > label::before {
   top: 4px;
   left: 0;
   width: 16px;
@@ -31,7 +31,7 @@
   border-radius: 2px;
 }
 
-.astro__checkbox > label::after {
+.a-checkbox > label::after {
   top: 8px;
   left: 3px;
   width: 11px;
@@ -42,7 +42,7 @@
   border-left: 2px solid;
 }
 
-.astro__checkbox--indeterminate > input[type='checkbox'] + label::after {
+.a-checkbox--indeterminate > input[type='checkbox'] + label::after {
   top: 11px;
   left: 4px;
   width: 8px;
@@ -50,23 +50,23 @@
   border-left: 0;
 }
 
-.astro__checkbox > input[type='checkbox'] + label::after {
+.a-checkbox > input[type='checkbox'] + label::after {
   content: none;
 }
 
-.astro__checkbox > input[type='checkbox']:checked + label::after {
+.a-checkbox > input[type='checkbox']:checked + label::after {
   content: '';
 }
 
-.astro__checkbox > input[type='checkbox']:checked + label::before {
+.a-checkbox > input[type='checkbox']:checked + label::before {
   border-color: var(--color-uranus-500);
   background-color: var(--color-uranus-500);
 }
 
-.astro__checkbox > input[type='checkbox']:disabled + label::before {
+.a-checkbox > input[type='checkbox']:disabled + label::before {
   opacity: 0.5;
 }
 
-.astro__checkbox > input[type='checkbox']:hover:not(:disabled) + label::before {
+.a-checkbox > input[type='checkbox']:hover:not(:disabled) + label::before {
   border-color: var(--color-uranus-500);
 }

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -1,13 +1,13 @@
-.checkbox > input[type='checkbox'] {
+.astro__checkbox > input[type='checkbox'] {
   opacity: 0;
 }
 
-.checkbox--disabled {
+.astro__checkbox--disabled {
   cursor: not-allowed;
   opacity: 0.2;
 }
 
-.checkbox > label {
+.astro__checkbox > label {
   position: relative;
   display: inline-block;
   padding-left: 24px;
@@ -15,14 +15,14 @@
   font-size: 16px;
 }
 
-.checkbox > label::before,
-.checkbox > label::after {
+.astro__checkbox > label::before,
+.astro__checkbox > label::after {
   position: absolute;
   display: inline-block;
   content: '';
 }
 
-.checkbox > label::before {
+.astro__checkbox > label::before {
   top: 4px;
   left: 0;
   width: 16px;
@@ -31,7 +31,7 @@
   border-radius: 2px;
 }
 
-.checkbox > label::after {
+.astro__checkbox > label::after {
   top: 8px;
   left: 3px;
   width: 11px;
@@ -42,7 +42,7 @@
   border-left: 2px solid;
 }
 
-.checkbox--indeterminate > input[type='checkbox'] + label::after {
+.astro__checkbox--indeterminate > input[type='checkbox'] + label::after {
   top: 11px;
   left: 4px;
   width: 8px;
@@ -50,23 +50,23 @@
   border-left: 0;
 }
 
-.checkbox > input[type='checkbox'] + label::after {
+.astro__checkbox > input[type='checkbox'] + label::after {
   content: none;
 }
 
-.checkbox > input[type='checkbox']:checked + label::after {
+.astro__checkbox > input[type='checkbox']:checked + label::after {
   content: '';
 }
 
-.checkbox > input[type='checkbox']:checked + label::before {
+.astro__checkbox > input[type='checkbox']:checked + label::before {
   border-color: var(--color-uranus-500);
   background-color: var(--color-uranus-500);
 }
 
-.checkbox > input[type='checkbox']:disabled + label::before {
+.astro__checkbox > input[type='checkbox']:disabled + label::before {
   opacity: 0.5;
 }
 
-.checkbox > input[type='checkbox']:hover:not(:disabled) + label::before {
+.astro__checkbox > input[type='checkbox']:hover:not(:disabled) + label::before {
   border-color: var(--color-uranus-500);
 }

--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -1,0 +1,5 @@
+:root {
+  --font-primary: 600 16px/1.5 Poppins, sans-serif;
+  --font-secondary: 500 16px/1.5 Lato, sans-serif;
+  --font-color: var(--color-moon-900);
+}

--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -1,5 +1,5 @@
 :root {
-  --font-primary: 600 16px/1.5 Poppins, sans-serif;
-  --font-secondary: 500 16px/1.5 Lato, sans-serif;
+  --font-primary: normal normal 600 normal 16px/1.5 Poppins, sans-serif;
+  --font-secondary: normal normal 500 normal 16px/1.5 Lato, sans-serif;
   --font-color: var(--color-moon-900);
 }

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -1,6 +1,6 @@
 /* Display */
 
-.astro__text--display {
+.a-text--display {
   font: var(--font-primary);
   font-size: 64px;
   font-weight: 700;
@@ -9,19 +9,19 @@
 
 /* Title */
 
-.astro__title--large {
+.a-title--large {
   font: var(--font-primary);
   font-size: 48px;
   color: var(--font-color);
 }
 
-.astro__title--medium {
+.a-title--medium {
   font: var(--font-primary);
   font-size: 40px;
   color: var(--font-color);
 }
 
-.astro__title--small {
+.a-title--small {
   font: var(--font-primary);
   font-size: 32px;
   color: var(--font-color);
@@ -29,18 +29,18 @@
 
 /* Paragraph */
 
-.astro__text--large {
+.a-text--large {
   font: var(--font-primary);
   font-size: 24px;
   color: var(--font-color);
 }
 
-.astro__text--medium {
+.a-text--medium {
   font: var(--font-primary);
   color: var(--font-color);
 }
 
-.astro__text--small {
+.a-text--small {
   font: var(--font-primary);
   font-size: 12px;
   color: var(--font-color);
@@ -48,18 +48,18 @@
 
 /* Secondary font */
 
-.astro__text--secondary--large {
+.a-text--secondary--large {
   font: var(--font-secondary);
   font-size: 24px;
   color: var(--font-color);
 }
 
-.astro__text--secondary--medium {
+.a-text--secondary--medium {
   font: var(--font-secondary);
   color: var(--font-color);
 }
 
-.astro__text--secondary--small {
+.a-text--secondary--small {
   font: var(--font-secondary);
   font-size: 12px;
   color: var(--font-color);

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -1,33 +1,66 @@
-/* Looking for headings? They aren't here; headings are in h1-h4 element selectors in base.css file */
-
 /* Display */
 
-.text--display {
+.astro__text--display {
+  font: var(--font-primary);
   font-size: 64px;
   font-weight: 700;
+  color: var(--font-color);
 }
 
-/* Paragraph - medium size is in default p element */
+/* Title */
 
-p.text--small {
-  font-size: 12px;
+.astro__title--large {
+  font: var(--font-primary);
+  font-size: 48px;
+  color: var(--font-color);
 }
 
-p.text--large {
+.astro__title--medium {
+  font: var(--font-primary);
+  font-size: 40px;
+  color: var(--font-color);
+}
+
+.astro__title--small {
+  font: var(--font-primary);
+  font-size: 32px;
+  color: var(--font-color);
+}
+
+/* Paragraph */
+
+.astro__text--large {
+  font: var(--font-primary);
   font-size: 24px;
+  color: var(--font-color);
+}
+
+.astro__text--medium {
+  font: var(--font-primary);
+  color: var(--font-color);
+}
+
+.astro__text--small {
+  font: var(--font-primary);
+  font-size: 12px;
+  color: var(--font-color);
 }
 
 /* Secondary font */
 
-p.text--secondary {
-  font-family: 'Lato', sans-serif;
+.astro__text--secondary--large {
+  font: var(--font-secondary);
   font-size: 24px;
+  color: var(--font-color);
 }
 
-p.text--secondary.text--small {
-  font-size: 16px;
+.astro__text--secondary--medium {
+  font: var(--font-secondary);
+  color: var(--font-color);
 }
 
-p.text--secondary.text--large {
-  font-size: 32px;
+.astro__text--secondary--small {
+  font: var(--font-secondary);
+  font-size: 12px;
+  color: var(--font-color);
 }

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -1,66 +1,60 @@
+/* Default styles */
+
+.a-text--display,
+.a-title--large,
+.a-title--medium,
+.a-title--small,
+.a-text--large,
+.a-text--medium,
+.a-text--small {
+  font: var(--font-primary);
+  color: var(--font-color);
+}
+
+.a-text--secondary-large,
+.a-text--secondary-medium,
+.a-text--secondary-small {
+  font: var(--font-secondary);
+  color: var(--font-color);
+}
+
 /* Display */
 
 .a-text--display {
-  font: var(--font-primary);
   font-size: 64px;
   font-weight: 700;
-  color: var(--font-color);
 }
 
 /* Title */
 
 .a-title--large {
-  font: var(--font-primary);
   font-size: 48px;
-  color: var(--font-color);
 }
 
 .a-title--medium {
-  font: var(--font-primary);
   font-size: 40px;
-  color: var(--font-color);
 }
 
 .a-title--small {
-  font: var(--font-primary);
   font-size: 32px;
-  color: var(--font-color);
 }
 
 /* Paragraph */
 
 .a-text--large {
-  font: var(--font-primary);
   font-size: 24px;
-  color: var(--font-color);
-}
-
-.a-text--medium {
-  font: var(--font-primary);
-  color: var(--font-color);
 }
 
 .a-text--small {
-  font: var(--font-primary);
   font-size: 12px;
-  color: var(--font-color);
 }
 
 /* Secondary font */
 
-.a-text--secondary--large {
-  font: var(--font-secondary);
+.a-text--secondary-large {
   font-size: 24px;
-  color: var(--font-color);
 }
 
-.a-text--secondary--medium {
-  font: var(--font-secondary);
-  color: var(--font-color);
-}
-
-.a-text--secondary--small {
-  font: var(--font-secondary);
+.a-text--secondary-small {
   font-size: 12px;
-  color: var(--font-color);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import '../node_modules/normalize.css/normalize.css';
 @import '../node_modules/flexboxgrid/dist/flexboxgrid.min.css';
 @import './css/colors.css';
+@import './css/fonts.css';
 @import './css/base.css';
 @import './css/typography.css';
 @import './css/checkbox.css';


### PR DESCRIPTION
# What

* Dissociate Astro from HTML structure and use CSS classes instead;
* Update Typography specs.

# Why

When trying to import Astro on legacy code projects, there were several breaks caused by our strict style rules, which caused us to decide to change implementation approach to something a little softer and more gradual/optional.

# How

* Change the CSS selection structure, from selecting HTML tags to using specific classes;
* Add `astro__` prefixes to classes in order to minimize conflicts with outer CSS styles;
* Update Typography to reflect recent design spec changes;
* Create `fonts.css` to store default primary and secondary font settings;
* Update Readme and make a few adjustments on the docs to reflect the changes.