### PR TITLE
Fix disabled state inconsistencies in Controls & Toggles

### DIFF
--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -96,13 +96,8 @@ Mouseover to view `:hover` state.
   </div>
 
   <div className="a-toggle a-toggle--disabled">
-    <label htmlFor="toggle3">off disabled</label>
+    <label htmlFor="toggle3">disabled</label>
     <input type="checkbox" id="toggle3" disabled />
-  </div>
-
-  <div className="a-toggle a-toggle--disabled">
-    <label htmlFor="toggle4">on disabled</label>
-    <input type="checkbox" id="toggle4" checked disabled />
   </div>
 </Playground>
 

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -4,7 +4,7 @@
 
 .a-checkbox--disabled > label {
   cursor: not-allowed;
-  opacity: 0.2;
+  color: var(--color-moon-200);
 }
 
 .a-checkbox > label {
@@ -55,7 +55,7 @@
 }
 
 .a-checkbox > input[type='checkbox']:disabled + label::before {
-  opacity: 0.5;
+  border-color: var(--color-moon-200);
 }
 
 .a-checkbox > input[type='checkbox']:hover:not(:disabled) + label::before {

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -1,3 +1,5 @@
+/* stylelint-disable no-descending-specificity */
+
 .a-checkbox > input[type='checkbox'] {
   opacity: 0;
 }
@@ -49,9 +51,17 @@
   border-left: 0;
 }
 
+.a-checkbox--indeterminate > input[type='checkbox']:disabled + label::after {
+  background-color: var(--color-moon-200);
+}
+
 .a-checkbox > input[type='checkbox']:checked + label::before {
   border-color: var(--color-uranus-500);
   background-color: var(--color-uranus-500);
+}
+
+.a-checkbox > input[type='checkbox']:checked:disabled + label::before {
+  background-color: var(--color-moon-200);
 }
 
 .a-checkbox > input[type='checkbox']:disabled + label::before {

--- a/src/css/radio.css
+++ b/src/css/radio.css
@@ -46,11 +46,11 @@
 
 .a-radio--disabled > label {
   cursor: not-allowed;
-  opacity: 0.2;
+  color: var(--color-moon-200);
 }
 
 .a-radio > input[type='radio']:disabled + label::before {
-  opacity: 0.5;
+  border-color: var(--color-moon-200);
 }
 
 /* Hover state */

--- a/src/css/toggle.css
+++ b/src/css/toggle.css
@@ -79,11 +79,14 @@
 
 /* Disabled state */
 
+.a-toggle > input[type='checkbox']:disabled::before {
+  background-color: var(--color-moon-200);
+}
+
 .a-toggle--disabled > label,
 .a-toggle > input[type='checkbox']:disabled {
   cursor: not-allowed;
-  opacity: 0.3;
-  color: var(--color-moon-400);
+  color: var(--color-moon-200);
 }
 
 /* Cursor */

--- a/src/css/toggle.css
+++ b/src/css/toggle.css
@@ -1,3 +1,5 @@
+/* stylelint-disable no-descending-specificity */
+
 /* Variables */
 
 .a-toggle {


### PR DESCRIPTION
# What
Fix a few disabled state color inconsistencies in Controls & Toggles components.

# Why
In those components, the shades of grey in their disabled states were a little inconsistent with the design specs.

# How
* Remove all use of `opacity` in disabled states. Change the component colors directly instead, to `moon 200`, which is the official disabled state color.
* Remove the blue color in the `on disabled` toggle component, after checking with design, because from their UX point of view it's best to keep all disabled stuff in grey.
* Also cover the scenarios in which the same component could be `checked` and `disabled`, which was not covered yet.

They will all look exactly the same now <3

**Before** | **After**
-|-
<img width="165" alt="screen shot 2019-02-20 at 16 01 33" src="https://user-images.githubusercontent.com/25252211/53117469-be0d8880-3529-11e9-967a-6cf21116eff3.png">|<img width="154" alt="screen shot 2019-02-20 at 16 01 10" src="https://user-images.githubusercontent.com/25252211/53117465-bd74f200-3529-11e9-83dc-dc0b306b192f.png">
<img width="126" alt="screen shot 2019-02-20 at 16 01 28" src="https://user-images.githubusercontent.com/25252211/53117468-be0d8880-3529-11e9-9a04-9797d0a32802.png">|<img width="126" alt="screen shot 2019-02-20 at 16 01 16" src="https://user-images.githubusercontent.com/25252211/53117467-be0d8880-3529-11e9-93bd-ddf1a8e7e1e7.png">
<img width="349" alt="screen shot 2019-02-20 at 16 01 48" src="https://user-images.githubusercontent.com/25252211/53117654-265c6a00-352a-11e9-98b9-2413d2172195.png">|<img width="372" alt="screen shot 2019-02-20 at 19 13 22" src="https://user-images.githubusercontent.com/25252211/53128457-9deac300-3543-11e9-8422-1bb9778d007a.png">

