### PR TITLE
Fix controls toggles page warnings

### DIFF
--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -23,7 +23,7 @@ Mouseover to view `:hover` state.
   </div>
 
   <div className="a-radio">
-    <input type="radio" id="radio2" name="radiogroup1" checked />
+    <input type="radio" id="radio2" name="radiogroup1" defaultChecked />
     <label htmlFor="radio2">Selected</label>
   </div>
 
@@ -63,12 +63,12 @@ Mouseover to view `:hover` state.
   </div>
 
   <div className="a-checkbox">
-    <input type="checkbox" id="checkbox2" checked />
+    <input type="checkbox" id="checkbox2" defaultChecked />
     <label htmlFor="checkbox2">Checked</label>
   </div>
 
   <div className="a-checkbox a-checkbox--indeterminate">
-    <input type="checkbox" id="checkbox3" checked />
+    <input type="checkbox" id="checkbox3" defaultChecked />
     <label htmlFor="checkbox3">Indeterminate</label>
   </div>
 
@@ -92,7 +92,7 @@ Mouseover to view `:hover` state.
 
   <div className="a-toggle">
     <label htmlFor="toggle2">on</label>
-    <input type="checkbox" id="toggle2" checked />
+    <input type="checkbox" id="toggle2" defaultChecked />
   </div>
 
   <div className="a-toggle a-toggle--disabled">


### PR DESCRIPTION
# What
Fix controls toggles page warnings

# Why
On controls and toggles page, we had some warnings around `checked` property on inputs.

# How
-  Added `defaultChecked` property instead `checked` to remove the warning
