### PR TITLE
Create release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This page documents interesting or noteworthy changes to the project, based on [Semantic Versioning](http://semver.org/).
 
+### [0.4.0] - 2019-02-26
+- Set Yarn as the only dependency manager.
+- Add slider components to Controls & Toggles.
+- Fix disabled state color inconsistencies in Controls & Toggles.
+- Create Inputs page and add standard input components.
+- Add SVG's to dist/assets folder in the Astro build.
+- Minor improvements in the docs homepage.
+
 ### [0.3.0] - 2019-02-08
 - Add toggle and radio button components to Controls & Toggles.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Magnetis (https://github.com/magnetis)",
   "homepage": "https://magnetis.github.io/astro/#/",
   "description": "Magnetis design system",


### PR DESCRIPTION
Changelog:

- Set Yarn as the only dependency manager.
- Add slider components to Controls & Toggles.
- Fix disabled state color inconsistencies in Controls & Toggles.
- Create Inputs page and add standard input components.
- Add SVG's to dist/assets folder in the Astro build.
- Minor improvements in the docs homepage.
