### PR TITLE
Fix input font and spacing

### DIFF
--- a/docs/inputs.mdx
+++ b/docs/inputs.mdx
@@ -30,7 +30,7 @@ The floating label will need JS to work on your project. You may find the code f
   </div>
 
   <div className="a-input a-input--invalid">      
-    <input type="text" defaultValue="Astro Team"/>
+    <input type="text" defaultValue="XYZK2"/>
     <label>Invalid</label>
     <span className="a-input__error">Invalid data</span>
   </div>

--- a/public/docz.html
+++ b/public/docz.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link href="https://fonts.googleapis.com/css?family=Poppins:500,600,700" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet"> 
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet"> 
     <title>{{ title }}</title>
     {{ head }}
   </head>

--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -1,5 +1,5 @@
 :root {
   --font-primary: normal normal 600 normal 16px/1.5 Poppins, sans-serif;
-  --font-secondary: normal normal 500 normal 16px/1.5 Lato, sans-serif;
+  --font-secondary: normal normal 400 normal 16px/1.5 Lato, sans-serif;
   --font-color: var(--color-moon-900);
 }

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -5,10 +5,12 @@
 
 .a-input > input {
   width: 100%;
-  padding: 22px 44px 12px 16px;
+  padding: 25px 44px 5px 16px;
   border: 1px solid var(--color-moon-500);
   border-radius: 8px;
   background-color: var(--color-space-100);
+  font: var(--font-secondary);
+  color: var(--font-color);
 }
 
 .a-input > label {
@@ -42,16 +44,16 @@
 }
 
 .a-input > input:focus + label {
-  top: 5px;
+  top: 8px;
   color: var(--color-uranus-500);
   font-size: 12px;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 .a-input > .a-input--floating-label {
-  top: 5px;
+  top: 8px;
   font-size: 12px;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 .a-input--validated > input:focus + label {


### PR DESCRIPTION
# What

Fix inconsistencies with design specs in input components: spacing and labels.

# Why

Design team spotted the inconsistencies in the production version of the documentation.

# How

* Adjust font directly on input selectors;
* Adjust spacing according to the specs;
* Fix Lato default font weight, which was wrong (500 to 400) and add `700` weight to the font download.

# Sample

<img width="859" alt="screen shot 2019-02-27 at 16 08 16" src="https://user-images.githubusercontent.com/25252211/53515955-ece7a980-3aa9-11e9-8f61-73bb1bf78c7e.png">
