### PR TITLE
Add a CNAME in order to resolve the DNS

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+astro.magnetis.com.br


### PR DESCRIPTION
Github says we need to define it in order to find the correct repo,
since we had to set a CNAME record pointing to magnetis.github.io

# What

A CNAME configuration file.

# Why

Because we need that to tell Github to route the traffic to this repository.

# How

We had to configure in our DNS. If you run `dig astro.magnetis.com.br`, you can check the configuration.

# Sample

Result of dig:

![screen shot 2019-03-07 at 16 38 17](https://user-images.githubusercontent.com/381213/53984129-6eb58380-40f7-11e9-81fc-48175785cf0e.png)
