### PR TITLE
Revert DNS changes

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-astro.magnetis.com.br

--- a/doczrc.js
+++ b/doczrc.js
@@ -2,7 +2,7 @@ import { css } from 'docz-plugin-css';
 
 export default {
   hashRouter: true,
-  base: '/',
+  base: '/astro', // TODO: Remove this if we move to a root domain like `astro.magnetis.com.br`.
   plugins: [
     css({
       preprocessor: 'postcss'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@magnetis/astro",
   "version": "0.4.1",
   "author": "Magnetis (https://github.com/magnetis)",
-  "homepage": "https://astro.magnetis.com.br/",
+  "homepage": "https://magnetis.github.io/astro/#/",
   "description": "Magnetis design system",
   "bugs": {
     "url": "https://github.com/magnetis/astro/issues"


### PR DESCRIPTION
# What

This reverts changes I made about DNS. 

# Why

It is not working because Docz does not recognize the new host. I'm not sure why yet.

# How

It was a `git revert SHA1` from the two commits, and also I let the field `Custom domain` empty in the project configuration.

# Sample

Here is the error I got from the browser:

![screen shot 2019-03-07 at 19 40 42](https://user-images.githubusercontent.com/381213/53994378-f1970800-4110-11e9-89bc-1a134aca8925.png)
