### PR TITLE
Add a subdomain for Astro

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+astro.magnetis.com.br

--- a/doczrc.js
+++ b/doczrc.js
@@ -2,7 +2,7 @@ import { css } from 'docz-plugin-css';
 
 export default {
   hashRouter: true,
-  base: '/astro', // TODO: Remove this if we move to a root domain like `astro.magnetis.com.br`.
+  base: '/',
   plugins: [
     css({
       preprocessor: 'postcss'


### PR DESCRIPTION
Now we can access it from https://astro.magnetis.com.br
Thanks @larimaza!

# What

A new subdomain for the project.

# Why

To make easier to access.

# How
Changing the DNS and deploying with `yarn docs:publish`

# Sample

https://astro.magnetis.com.br
