### PR TITLE
Fix single quote formatting in .mdx files

### DIFF
--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -18,19 +18,11 @@ Use these for the main action in a section or screen. You should display only on
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="a-btn a-btn--uranus a-btn--medium">
-    uranus
-  </button>
-
-<button className='a-btn a-btn--earth a-btn--medium'>earth</button>
-
-<button className='a-btn a-btn--venus a-btn--medium'>venus</button>
-
-  <button className="a-btn a-btn--mars a-btn--medium">
-    mars
-  </button>
-  
-  <button className="a-btn a-btn--uranus a-btn--medium" disabled>
+  <button className='a-btn a-btn--uranus a-btn--medium'>uranus</button>
+  <button className='a-btn a-btn--earth a-btn--medium'>earth</button>
+  <button className='a-btn a-btn--venus a-btn--medium'>venus</button>
+  <button className='a-btn a-btn--mars a-btn--medium'>mars</button>
+  <button className='a-btn a-btn--uranus a-btn--medium' disabled>
     disabled
   </button>
 </Playground>
@@ -44,23 +36,19 @@ Please note that there are color variations to the outline CSS classes. You also
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="a-btn a-btn--outline-uranus a-btn--medium">
+  <button className='a-btn a-btn--outline-uranus a-btn--medium'>
     outline uranus
   </button>
-
-<button className='a-btn a-btn--outline-earth a-btn--medium'>
-  outline earth
-</button>
-
-<button className='a-btn a-btn--outline-venus a-btn--medium'>
-  outline venus
-</button>
-
-  <button className="a-btn a-btn--outline-mars a-btn--medium">
+  <button className='a-btn a-btn--outline-earth a-btn--medium'>
+    outline earth
+  </button>
+  <button className='a-btn a-btn--outline-venus a-btn--medium'>
+    outline venus
+  </button>
+  <button className='a-btn a-btn--outline-mars a-btn--medium'>
     outline mars
   </button>
- 
-  <button className="a-btn a-btn--outline-venus a-btn--medium" disabled>
+  <button className='a-btn a-btn--outline-venus a-btn--medium' disabled>
     outline disabled
   </button>
 </Playground>
@@ -74,19 +62,17 @@ Aside from using the ghost button CSS class, you also need to specify size and c
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <button className="a-btn a-btn--ghost-uranus a-btn--medium">
+  <button className='a-btn a-btn--ghost-uranus a-btn--medium'>
     ghost uranus
   </button>
-
-<button className='a-btn a-btn--ghost-earth a-btn--medium'>ghost earth</button>
-
-<button className='a-btn a-btn--ghost-venus a-btn--medium'>ghost venus</button>
-
-  <button className="a-btn a-btn--ghost-mars a-btn--medium">
-    ghost mars
+  <button className='a-btn a-btn--ghost-earth a-btn--medium'>
+    ghost earth
   </button>
- 
-  <button className="a-btn a-btn--ghost-venus a-btn--medium" disabled>
+  <button className='a-btn a-btn--ghost-venus a-btn--medium'>
+    ghost venus
+  </button>
+  <button className='a-btn a-btn--ghost-mars a-btn--medium'>ghost mars</button>
+  <button className='a-btn a-btn--ghost-venus a-btn--medium' disabled>
     ghost disabled
   </button>
 </Playground>
@@ -96,17 +82,9 @@ Mouseover and click to view `:hover` and `:active` states.
 Buttons can have different sizes, also by changing their CSS size class.
 
 <Playground>
-  <button className="a-btn a-btn--uranus a-btn--small">
-    small
-  </button>
- 
-  <button className="a-btn a-btn--uranus a-btn--medium">
-    medium
-  </button>
-
-  <button className="a-btn a-btn--uranus a-btn--large">
-    large
-  </button>
+  <button className='a-btn a-btn--uranus a-btn--small'>small</button>
+  <button className='a-btn a-btn--uranus a-btn--medium'>medium</button>
+  <button className='a-btn a-btn--uranus a-btn--large'>large</button>
 </Playground>
 
 <Playground>

--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -21,40 +21,38 @@ Mouseover to view `:hover` state.
 To create the disabled state, add the `a-radio--disabled` modifier class on element root and `disabled` attribute on the `<input>` tag.
 
 <Playground>
-  <div className="a-radio">
-    <label htmlFor="radio1">Radio</label>
-    <input type="radio" id="radio1" name="radiogroup1" />
+  <div className='a-radio'>
+    <label htmlFor='radio1'>Radio</label>
+    <input type='radio' id='radio1' name='radiogroup1' />
   </div>
-
-  <div className="a-radio">
-    <label htmlFor="radio2">Selected</label>
-    <input type="radio" id="radio2" name="radiogroup1" defaultChecked />
+  <div className='a-radio'>
+    <label htmlFor='radio2'>Selected</label>
+    <input type='radio' id='radio2' name='radiogroup1' defaultChecked />
   </div>
-
-  <div className="a-radio a-radio--disabled">
-    <label htmlFor="radio3">Disabled</label>
-    <input type="radio" id="radio3" name="radiogroup1" disabled />
+  <div className='a-radio a-radio--disabled'>
+    <label htmlFor='radio3'>Disabled</label>
+    <input type='radio' id='radio3' name='radiogroup1' disabled />
   </div>
 </Playground>
 
 Default label behavior is top alignment. You can add the `a-radio--align-middle` modifier class to switch to middle alignment.
 
 <Playground>
-  <div className="a-radio">
-    <label htmlFor="radio4">
+  <div className='a-radio'>
+    <label htmlFor='radio4'>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Sed risus pretium quam
       vulputate dignissim suspendisse.
     </label>
-    <input type="radio" id="radio4" name="radiogroup2" />
+    <input type='radio' id='radio4' name='radiogroup2' />
   </div>
-  <div className="a-radio a-radio--align-middle">
-    <label htmlFor="radio5">
+  <div className='a-radio a-radio--align-middle'>
+    <label htmlFor='radio5'>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Sed risus pretium quam
       vulputate dignissim suspendisse.
     </label>
-    <input type="radio" id="radio5" name="radiogroup2" />
+    <input type='radio' id='radio5' name='radiogroup2' />
   </div>
 </Playground>
 
@@ -67,24 +65,21 @@ Mouseover to view `:hover` state.
 To create the disabled state, add the `a-checkbox--disabled` modifier class on element root and `disabled` attribute on the `<input>` tag.
 
 <Playground>
-  <div className="a-checkbox">
-    <label htmlFor="checkbox1">Checkbox</label>
-    <input type="checkbox" id="checkbox1" />
+  <div className='a-checkbox'>
+    <label htmlFor='checkbox1'>Checkbox</label>
+    <input type='checkbox' id='checkbox1' />
   </div>
-
-  <div className="a-checkbox">
-    <label htmlFor="checkbox2">Checked</label>
-    <input type="checkbox" id="checkbox2" defaultChecked />
+  <div className='a-checkbox'>
+    <label htmlFor='checkbox2'>Checked</label>
+    <input type='checkbox' id='checkbox2' defaultChecked />
   </div>
-
-  <div className="a-checkbox a-checkbox--indeterminate">
-    <label htmlFor="checkbox3">Indeterminate</label>
-    <input type="checkbox" id="checkbox3" defaultChecked />
+  <div className='a-checkbox a-checkbox--indeterminate'>
+    <label htmlFor='checkbox3'>Indeterminate</label>
+    <input type='checkbox' id='checkbox3' defaultChecked />
   </div>
-
-  <div className="a-checkbox a-checkbox--disabled">
-    <label htmlFor="checkbox4">Disabled</label>
-    <input type="checkbox" id="checkbox4" disabled />
+  <div className='a-checkbox a-checkbox--disabled'>
+    <label htmlFor='checkbox4'>Disabled</label>
+    <input type='checkbox' id='checkbox4' disabled />
   </div>
 </Playground>
 
@@ -97,19 +92,17 @@ Mouseover to view `:hover` state.
 To create the disabled state, add the `a-toggle--disabled` modifier class on element root and `disabled` attribute on the `<input>` tag.
 
 <Playground>
-  <div className="a-toggle">
-    <label htmlFor="toggle1">off</label>
-    <input type="checkbox" id="toggle1" />
+  <div className='a-toggle'>
+    <label htmlFor='toggle1'>off</label>
+    <input type='checkbox' id='toggle1' />
   </div>
-
-<div className='a-toggle'>
-  <label htmlFor='toggle2'>on</label>
-  <input type='checkbox' id='toggle2' defaultChecked />
-</div>
-
-  <div className="a-toggle a-toggle--disabled">
-    <label htmlFor="toggle3">disabled</label>
-    <input type="checkbox" id="toggle3" disabled />
+  <div className='a-toggle'>
+    <label htmlFor='toggle2'>on</label>
+    <input type='checkbox' id='toggle2' defaultChecked />
+  </div>
+  <div className='a-toggle a-toggle--disabled'>
+    <label htmlFor='toggle3'>disabled</label>
+    <input type='checkbox' id='toggle3' disabled />
   </div>
 </Playground>
 
@@ -128,20 +121,19 @@ Mouseover and click to view `:hover` and `:active` state.
 To create the disabled state, add the `a-slider--disabled` modifier class on element root and `disabled` attribute on the `<input>` tag.
 
 <Playground>
-  <div className="a-slider">
-    <label htmlFor="slider1">
+  <div className='a-slider'>
+    <label htmlFor='slider1'>
       Slider
-      <span className="a-slider--value">50 coins</span>
+      <span className='a-slider--value'>50 coins</span>
     </label>
-    <input type="range" min="1" max="100" id="slider1" />
+    <input type='range' min='1' max='100' id='slider1' />
   </div>
-
-  <div className="a-slider a-slider--disabled">
-    <label htmlFor="slider1">
+  <div className='a-slider a-slider--disabled'>
+    <label htmlFor='slider1'>
       Disabled
-      <span className="a-slider--value">0 coins</span>
+      <span className='a-slider--value'>0 coins</span>
     </label>
-    <input type="range" min="1" max="100" id="slider1" disabled />
+    <input type='range' min='1' max='100' id='slider1' disabled />
   </div>
 </Playground>
 
@@ -156,64 +148,65 @@ Each tab can be created both with or without Astro icons. To add an icon, follow
 Mouseover to view `:hover` state, and click on a tab to see its content.
 
 <Playground>
-  <div className="a-tabs">
-    <input className="a-tabs__item" type="radio" id="tab1" name="tabs1" defaultChecked />
-    <label className="a-tabs__label" htmlFor="tab1">
-      <i className="a-icon a-icon__calendar a-icon--space-right a-tabs__icon" />
-      <span className="a-tabs__text">Tab 1</span>
+  <div className='a-tabs'>
+    <input
+      className='a-tabs__item'
+      type='radio'
+      id='tab1'
+      name='tabs1'
+      defaultChecked
+    />
+    <label className='a-tabs__label' htmlFor='tab1'>
+      <i className='a-icon a-icon__calendar a-icon--space-right a-tabs__icon' />
+      <span className='a-tabs__text'>Tab 1</span>
     </label>
-    <div className="a-tabs__content">
-      <h2 className="a-title--large">tab 1</h2>
-      <p className="a-text--secondary-medium">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        In euismod nisi in orci mattis, ac iaculis orci lobortis.
+    <div className='a-tabs__content'>
+      <h2 className='a-title--large'>tab 1</h2>
+      <p className='a-text--secondary-medium'>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. In euismod nisi
+        in orci mattis, ac iaculis orci lobortis.
       </p>
-      <p className="a-text--secondary-medium">
-        Nullam imperdiet dolor a erat commodo laoreet a ut felis.
-        Nam consequat nisl eu efficitur suscipit.
-        Nulla dapibus cursus diam in convallis.
-      </p>
-    </div>
-
-    <input className="a-tabs__item" type="radio" id="tab2" name="tabs1" />
-    <label className="a-tabs__label" htmlFor="tab2">
-      <i className="a-icon a-icon__mail a-icon--space-right a-tabs__icon" />
-      <span className="a-tabs__text">Tab 2</span>
-    </label>
-    <div className="a-tabs__content">
-      <h2 className="a-title--large">tab 2</h2>
-      <p className="a-text--secondary-medium">
-        Integer id pulvinar odio, sit amet accumsan lacus.
-        Pellentesque accumsan sapien eget orci auctor, ac pulvinar orci porttitor.
-        Sed fermentum turpis sed egestas commodo.
-        In euismod nisi in orci mattis, ac iaculis orci lobortis.
+      <p className='a-text--secondary-medium'>
+        Nullam imperdiet dolor a erat commodo laoreet a ut felis. Nam consequat
+        nisl eu efficitur suscipit. Nulla dapibus cursus diam in convallis.
       </p>
     </div>
-
-    <input className="a-tabs__item" type="radio" id="tab3" name="tabs1" />
-    <label className="a-tabs__label" htmlFor="tab3">
-      <i className="a-icon a-icon__profile a-icon--space-right a-tabs__icon" />
-      <span className="a-tabs__text">Tab 3</span>
+    <input className='a-tabs__item' type='radio' id='tab2' name='tabs1' />
+    <label className='a-tabs__label' htmlFor='tab2'>
+      <i className='a-icon a-icon__mail a-icon--space-right a-tabs__icon' />
+      <span className='a-tabs__text'>Tab 2</span>
     </label>
-    <div className="a-tabs__content">
-      <h2 className="a-title--large">tab 3</h2>
-      <p className="a-text--secondary-medium">
-        Quisque dictum erat lectus, ac dapibus orci ultricies vitae.
-        Suspendisse id vestibulum turpis.
+    <div className='a-tabs__content'>
+      <h2 className='a-title--large'>tab 2</h2>
+      <p className='a-text--secondary-medium'>
+        Integer id pulvinar odio, sit amet accumsan lacus. Pellentesque accumsan
+        sapien eget orci auctor, ac pulvinar orci porttitor. Sed fermentum
+        turpis sed egestas commodo. In euismod nisi in orci mattis, ac iaculis
+        orci lobortis.
       </p>
     </div>
-
-    <input className="a-tabs__item" type="radio" id="tab4" name="tabs1" />
-    <label className="a-tabs__label" htmlFor="tab4">
-      <span className="a-tabs__text">Tab 4</span>
+    <input className='a-tabs__item' type='radio' id='tab3' name='tabs1' />
+    <label className='a-tabs__label' htmlFor='tab3'>
+      <i className='a-icon a-icon__profile a-icon--space-right a-tabs__icon' />
+      <span className='a-tabs__text'>Tab 3</span>
     </label>
-    <div className="a-tabs__content">
-      <h2 className="a-title--large">tab 4</h2>
-      <p className="a-text--secondary-medium">
+    <div className='a-tabs__content'>
+      <h2 className='a-title--large'>tab 3</h2>
+      <p className='a-text--secondary-medium'>
+        Quisque dictum erat lectus, ac dapibus orci ultricies vitae. Suspendisse
+        id vestibulum turpis.
+      </p>
+    </div>
+    <input className='a-tabs__item' type='radio' id='tab4' name='tabs1' />
+    <label className='a-tabs__label' htmlFor='tab4'>
+      <span className='a-tabs__text'>Tab 4</span>
+    </label>
+    <div className='a-tabs__content'>
+      <h2 className='a-title--large'>tab 4</h2>
+      <p className='a-text--secondary-medium'>
         Nam consequat nisl eu efficitur suscipit vestibulum turpis.
       </p>
     </div>
-
-    <div className="a-tabs__border"></div>
+    <div className='a-tabs__border' />
   </div>
 </Playground>

--- a/docs/inputs.mdx
+++ b/docs/inputs.mdx
@@ -20,30 +20,51 @@ The floating label will need JS to work on your project. You may find the code f
 To create the disabled state, add the `a-input--disabled` modifier class on element root and `disabled` attribute on the `<input>` tag.
 
 <Playground>
-  <div className="a-input">
-    <input id="input1" type="text" aria-labelledby="label1" />
-    <label id="label1" htmlFor="input1">Standard</label>
+  <div className='a-input'>
+    <input id='input1' type='text' aria-labelledby='label1' />
+    <label id='label1' htmlFor='input1'>
+      Standard
+    </label>
   </div>
-
-  <div className="a-input a-input--validated">
-    <input id="input2" type="text" aria-labelledby="label2" defaultValue="Astro Team" />
-    <label id="label2" htmlFor="input2">Validated</label>
+  <div className='a-input a-input--validated'>
+    <input
+      id='input2'
+      type='text'
+      aria-labelledby='label2'
+      defaultValue='Astro Team'
+    />
+    <label id='label2' htmlFor='input2'>
+      Validated
+    </label>
   </div>
-
-  <div className="a-input a-input--invalid">
-    <input id="input3" type="text" aria-labelledby="label3" defaultValue="XYZK2" />
-    <label id="label3" htmlFor="input3">Invalid</label>
-    <span className="a-input__error">Invalid data</span>
+  <div className='a-input a-input--invalid'>
+    <input
+      id='input3'
+      type='text'
+      aria-labelledby='label3'
+      defaultValue='XYZK2'
+    />
+    <label id='label3' htmlFor='input3'>
+      Invalid
+    </label>
+    <span className='a-input__error'>Invalid data</span>
   </div>
-
-  <div className="a-input">
-    <input id="input4" type="text" aria-labelledby="label4" defaultValue="Astro Team" />
-    <label id="label4" htmlFor="input4">Filled</label>
+  <div className='a-input'>
+    <input
+      id='input4'
+      type='text'
+      aria-labelledby='label4'
+      defaultValue='Astro Team'
+    />
+    <label id='label4' htmlFor='input4'>
+      Filled
+    </label>
   </div>
-
-  <div className="a-input a-input--disabled">
-    <input id="input5" type="text" aria-labelledby="label5" disabled />
-    <label id="label5" htmlFor="input5">Disabled</label>
+  <div className='a-input a-input--disabled'>
+    <input id='input5' type='text' aria-labelledby='label5' disabled />
+    <label id='label5' htmlFor='input5'>
+      Disabled
+    </label>
   </div>
 </Playground>
 


### PR DESCRIPTION
# What

Fix the formatting of .mdx files in the project from inconsistent double/single quotes to all-single quotes.

# Why

Prettier wasn't able to format all .mdx files correctly when there's an empty paragraph between elements inside a `<Playground>`.

# How

Remove all empty paragraphs between elements.
