### PR TITLE
Create text area input classes and components

### DIFF
--- a/docs/inputs.mdx
+++ b/docs/inputs.mdx
@@ -68,4 +68,20 @@ To create the disabled state, add the `a-input--disabled` modifier class on elem
   </div>
 </Playground>
 
+## text area inputs
+
+Text areas are used in contexts that demand long and descriptive texts.
+
+<Playground>
+  <div className='a-input'>
+    <textarea name='random' id='textarea1' rows='10' cols='20'></textarea>
+    <label id='label6' htmlFor='textarea1'>Write your book here</label>
+  </div>
+
+  <div className='a-input a-input--disabled'>
+    <textarea name='random' id='textarea2' rows='10' cols='20' disabled></textarea>
+    <label id='label7' htmlFor='textarea2'>Disabled</label>
+  </div>
+</Playground>
+
 <HandleFloatingLabel />

--- a/docs/js/inputs.js
+++ b/docs/js/inputs.js
@@ -11,7 +11,7 @@ export const initFloatingLabel = () => {
     };
 
     inputs.forEach(input => {
-      const currentInput = input.querySelector("input");
+      const currentInput = input.firstChild;
       const currentLabel = input.querySelector("label");
 
       verifyValue(currentInput, currentLabel);

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -3,7 +3,8 @@
   display: inline-block;
 }
 
-.a-input > input {
+.a-input > input,
+.a-input > textarea {
   width: 100%;
   padding: 25px 44px 5px 16px;
   border: 1px solid var(--color-moon-500);
@@ -39,11 +40,13 @@
   color: var(--color-mars-500);
 }
 
-.a-input > input:focus {
+.a-input > input:focus,
+.a-input > textarea:focus {
   border: 1px solid var(--color-uranus-500);
 }
 
-.a-input > input:focus + label {
+.a-input > input:focus + label,
+.a-input > textarea:focus + label {
   top: 8px;
   color: var(--color-uranus-500);
   font-size: 12px;
@@ -103,13 +106,15 @@
   font-size: 12px;
 }
 
-.a-input--disabled > input:disabled {
+.a-input--disabled > input:disabled,
+.a-input--disabled > textarea:disabled {
   cursor: not-allowed;
   border: 1px solid var(--color-moon-200);
   background-color: var(--color-moon-100);
 }
 
-.a-input--disabled > input:disabled + label {
+.a-input--disabled > input:disabled + label,
+.a-input--disabled > textarea:disabled + label {
   cursor: not-allowed;
   color: var(--color-moon-300);
   font: var(--font-secondary);


### PR DESCRIPTION
# What

This PR creates the styles for textarea components on docz.

# Why

Textarea elements are important in form inputs to get longer kinds of text from the user.
Their style should be consistent with the design system.

# How

- Create CSS file for textarea tag classes
- Add textarea component playground in `inputs.mdx`

# Sample

![Screenshot](https://screenshots.firefox.com/RaZQyj63czN9Wiao/localhost "Preview")