### PR TITLE
Fix icon size on the tabs component

### DIFF
--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -157,7 +157,7 @@ Mouseover to view `:hover` state, and click on a tab to see its content.
       defaultChecked
     />
     <label className='a-tabs__label' htmlFor='tab1'>
-      <i className='a-icon a-icon__calendar a-icon--space-right a-tabs__icon' />
+      <i className='a-icon a-icon__calendar a-icon--size-small a-icon--space-right a-tabs__icon' />
       <span className='a-tabs__text'>Tab 1</span>
     </label>
     <div className='a-tabs__content'>
@@ -173,7 +173,7 @@ Mouseover to view `:hover` state, and click on a tab to see its content.
     </div>
     <input className='a-tabs__item' type='radio' id='tab2' name='tabs1' />
     <label className='a-tabs__label' htmlFor='tab2'>
-      <i className='a-icon a-icon__mail a-icon--space-right a-tabs__icon' />
+      <i className='a-icon a-icon__mail a-icon--size-small a-icon--space-right a-tabs__icon' />
       <span className='a-tabs__text'>Tab 2</span>
     </label>
     <div className='a-tabs__content'>
@@ -187,7 +187,7 @@ Mouseover to view `:hover` state, and click on a tab to see its content.
     </div>
     <input className='a-tabs__item' type='radio' id='tab3' name='tabs1' />
     <label className='a-tabs__label' htmlFor='tab3'>
-      <i className='a-icon a-icon__profile a-icon--space-right a-tabs__icon' />
+      <i className='a-icon a-icon__profile a-icon--size-small a-icon--space-right a-tabs__icon' />
       <span className='a-tabs__text'>Tab 3</span>
     </label>
     <div className='a-tabs__content'>


### PR DESCRIPTION
# What

This PR fix the icon size on the tabs component.

# Why

We have recently changed some icon size settings that impacted the tabs component.

# How

* Add `a-icon--size-small` modifier to the icons classes.

# Sample

### Before fix

![Screenshot_from_2019-03-29_16-57-02](https://user-images.githubusercontent.com/1002072/55487746-12198b80-5605-11e9-8f4d-e774dea3561c.png)

### After fix

<img width="749" alt="Captura de Tela 2019-04-03 às 11 33 38" src="https://user-images.githubusercontent.com/1002072/55487593-c6ff7880-5604-11e9-8a0f-9c05ff5420d3.png">