### PR TITLE
Refactor Controls & Toggles to fix pseudoclass bug

### DIFF
--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -95,17 +95,17 @@ To create the disabled state, add the `a-toggle--disabled` modifier class on ele
   <div className='a-toggle'>
     <label htmlFor='toggle1'>off</label>
     <input type='checkbox' id='toggle1' />
-    <div className='a-toggle--shape' />
+    <span className='a-toggle__shape' />
   </div>
   <div className='a-toggle'>
     <label htmlFor='toggle2'>on</label>
     <input type='checkbox' id='toggle2' defaultChecked />
-    <div className='a-toggle--shape' />
+    <span className='a-toggle__shape' />
   </div>
   <div className='a-toggle a-toggle--disabled'>
     <label htmlFor='toggle3'>disabled</label>
     <input type='checkbox' id='toggle3' disabled />
-    <div className='a-toggle--shape' />
+    <span className='a-toggle__shape' />
   </div>
 </Playground>
 

--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -73,18 +73,22 @@ To create the disabled state, add the `a-checkbox--disabled` modifier class on e
   <div className='a-checkbox'>
     <label htmlFor='checkbox1'>Checkbox</label>
     <input type='checkbox' id='checkbox1' />
+    <span className='a-checkbox__shape' />
   </div>
   <div className='a-checkbox'>
     <label htmlFor='checkbox2'>Checked</label>
     <input type='checkbox' id='checkbox2' defaultChecked />
+    <span className='a-checkbox__shape' />
   </div>
   <div className='a-checkbox a-checkbox--indeterminate'>
     <label htmlFor='checkbox3'>Indeterminate</label>
     <input type='checkbox' id='checkbox3' defaultChecked />
+    <span className='a-checkbox__shape' />
   </div>
   <div className='a-checkbox a-checkbox--disabled'>
     <label htmlFor='checkbox4'>Disabled</label>
     <input type='checkbox' id='checkbox4' disabled />
+    <span className='a-checkbox__shape' />
   </div>
 </Playground>
 

--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -95,14 +95,17 @@ To create the disabled state, add the `a-toggle--disabled` modifier class on ele
   <div className='a-toggle'>
     <label htmlFor='toggle1'>off</label>
     <input type='checkbox' id='toggle1' />
+    <div className='a-toggle--shape' />
   </div>
   <div className='a-toggle'>
     <label htmlFor='toggle2'>on</label>
     <input type='checkbox' id='toggle2' defaultChecked />
+    <div className='a-toggle--shape' />
   </div>
   <div className='a-toggle a-toggle--disabled'>
     <label htmlFor='toggle3'>disabled</label>
     <input type='checkbox' id='toggle3' disabled />
+    <div className='a-toggle--shape' />
   </div>
 </Playground>
 

--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -24,14 +24,17 @@ To create the disabled state, add the `a-radio--disabled` modifier class on elem
   <div className='a-radio'>
     <label htmlFor='radio1'>Radio</label>
     <input type='radio' id='radio1' name='radiogroup1' />
+    <span className='a-radio__shape' />
   </div>
   <div className='a-radio'>
     <label htmlFor='radio2'>Selected</label>
     <input type='radio' id='radio2' name='radiogroup1' defaultChecked />
+    <span className='a-radio__shape' />    
   </div>
   <div className='a-radio a-radio--disabled'>
     <label htmlFor='radio3'>Disabled</label>
     <input type='radio' id='radio3' name='radiogroup1' disabled />
+    <span className='a-radio__shape' />
   </div>
 </Playground>
 
@@ -45,6 +48,7 @@ Default label behavior is top alignment. You can add the `a-radio--align-middle`
       vulputate dignissim suspendisse.
     </label>
     <input type='radio' id='radio4' name='radiogroup2' />
+    <span className='a-radio__shape' />
   </div>
   <div className='a-radio a-radio--align-middle'>
     <label htmlFor='radio5'>
@@ -53,6 +57,7 @@ Default label behavior is top alignment. You can add the `a-radio--align-middle`
       vulputate dignissim suspendisse.
     </label>
     <input type='radio' id='radio5' name='radiogroup2' />
+    <span className='a-radio__shape' />
   </div>
 </Playground>
 

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -2,6 +2,7 @@
   --checkbox-square-size: 16px;
 
   display: flex;
+  position: relative;
 }
 
 .a-checkbox > label {
@@ -17,17 +18,18 @@
 }
 
 .a-checkbox > input[type='checkbox'] {
-  position: relative;
-  visibility: hidden;
+  position: absolute;
   width: var(--checkbox-square-size);
   height: var(--checkbox-square-size);
   margin: 4px 0;
+  opacity: 0;
   order: 1;
+  cursor: pointer;
+  z-index: var(--z-index-1);
 }
 
-.a-checkbox > input[type='checkbox']::before {
+.a-checkbox__shape::before {
   display: inline-block;
-  visibility: visible;
   width: var(--checkbox-square-size);
   height: var(--checkbox-square-size);
   content: '';
@@ -35,12 +37,10 @@
   border-radius: 2px;
 }
 
-.a-checkbox > input[type='checkbox']::after {
+.a-checkbox__shape::after {
   position: absolute;
-  top: 3px;
+  top: 7px;
   left: 3px;
-  display: inline-block;
-  visibility: visible;
   width: 10px;
   height: 6px;
   content: '';
@@ -50,28 +50,28 @@
   border-left: 2px solid;
 }
 
-.a-checkbox--indeterminate > input[type='checkbox']::after {
-  top: 8px;
+.a-checkbox--indeterminate > .a-checkbox__shape::after {
+  top: 11px;
   left: 4px;
   width: 8px;
   transform: rotate(-180deg);
   border-left: 0;
 }
 
-.a-checkbox--indeterminate > input[type='checkbox']:disabled::before {
+.a-checkbox--indeterminate > input[type='checkbox']:disabled ~ .a-checkbox__shape::before {
   background-color: var(--color-moon-200);
 }
 
-.a-checkbox > input[type='checkbox']:checked::before {
+.a-checkbox > input[type='checkbox']:checked ~ .a-checkbox__shape::before {
   border-color: var(--color-uranus-500);
   background-color: var(--color-uranus-500);
 }
 
-.a-checkbox > input[type='checkbox']:disabled::before {
+.a-checkbox > input[type='checkbox']:disabled ~ .a-checkbox__shape::before {
   border-color: var(--color-moon-200);
 }
 
-.a-checkbox > input[type='checkbox']:checked:disabled::before {
+.a-checkbox > input[type='checkbox']:checked:disabled ~ .a-checkbox__shape::before {
   background-color: var(--color-moon-200);
 }
 
@@ -79,7 +79,6 @@
   cursor: not-allowed;
 }
 
-.a-checkbox > input[type='checkbox']:hover:not(:disabled) {
-  cursor: pointer;
+.a-checkbox > input[type='checkbox']:hover:not(:disabled) ~ .a-checkbox__shape::before {
   border-color: var(--color-uranus-500);
 }

--- a/src/css/radio.css
+++ b/src/css/radio.css
@@ -9,11 +9,13 @@
 /* Standard input */
 
 .a-radio > input[type='radio'] {
-  visibility: hidden;
+  position: absolute;
   width: var(--radio-circle-size);
   height: var(--radio-circle-size);
   margin-top: 4px;
+  opacity: 0;
   order: 1;
+  cursor: pointer;
 }
 
 /* Label design */
@@ -22,17 +24,16 @@
   padding-left: 8px;
   cursor: pointer;
   font: var(--font-secondary);
-  flex: 1;
   order: 2;
 }
 
 /* Radio button design */
 
-.a-radio > input[type='radio']::before {
+.a-radio__shape::before {
   display: inline-block;
-  visibility: visible;
   width: var(--radio-circle-size);
   height: var(--radio-circle-size);
+  margin-top: 4px;
   content: '';
   border: 2px solid var(--color-moon-500);
   border-radius: 100%;
@@ -51,31 +52,30 @@
 
 /* Checked state */
 
-.a-radio > input[type='radio']:checked::before {
+.a-radio > input[type='radio']:checked ~ .a-radio__shape::before {
   border: solid 5px var(--color-uranus-500);
 }
 
 /* Disabled state */
 
-.a-radio > input[type='radio']:disabled::before {
+.a-radio > input[type='radio']:disabled ~ .a-radio__shape::before {
   cursor: not-allowed;
   border-color: var(--color-moon-200);
 }
 
 .a-radio--disabled > label,
 .a-radio--disabled > input[type='radio']:disabled,
-.a-radio--disabled > input[type='radio']:disabled::before {
+.a-radio--disabled > input[type='radio']:disabled ~ .a-radio__shape::before {
   cursor: not-allowed;
   color: var(--color-moon-200);
 }
 
-.a-radio--disabled > input[type='radio']:disabled::before {
+.a-radio--disabled > input[type='radio']:disabled ~ .a-radio__shape::before {
   border-color: var(--color-moon-200);
 }
 
-/* Hover state */
+/* Hover state on */
 
-.a-radio > input[type='radio']:not(:disabled):hover::before {
-  cursor: pointer;
+.a-radio > input[type='radio']:not(:disabled):hover ~ .a-radio__shape::before {
   border-color: var(--color-uranus-500);
 }

--- a/src/css/slider.css
+++ b/src/css/slider.css
@@ -87,7 +87,8 @@
   display: none;
 }
 
-/* Firefox - always replicate styles for each browser, it's the only way :( */
+/* Firefox - always replicate styles for each browser, it's the only way :(
+  Some styles below are slightly different from Chrome */
 
 .a-slider > input[type='range']::-moz-range-track {
   background-image:
@@ -107,6 +108,7 @@
   appearance: none;
   width: 16px;
   height: 16px;
+  border: none;
   border-radius: 100%;
   background-color: var(--color-uranus-500);
   cursor: pointer;
@@ -126,6 +128,11 @@
   background-color: var(--color-uranus-400);
 }
 
+.a-slider > input[type='range']:disabled {
+  background-color: transparent;
+  cursor: not-allowed;
+}
+
 .a-slider > input[type='range']:disabled::-moz-range-track {
   background-image: none;
   background-color: var(--color-moon-200);
@@ -133,7 +140,7 @@
 }
 
 .a-slider > input[type='range']:disabled::-moz-range-thumb {
-  display: none;
+  visibility: hidden;
 }
 
 /* IE - always replicate styles for each browser, it's the only way :( */

--- a/src/css/toggle.css
+++ b/src/css/toggle.css
@@ -11,7 +11,7 @@
 
 /* Hide standard input */
 
-.a-toggle input[type='checkbox'] {
+.a-toggle > input[type='checkbox'] {
   position: absolute;
   top: 0;
   left: 0;
@@ -25,21 +25,21 @@
 
 /* Label */
 
-.a-toggle label {
+.a-toggle > label {
   padding-right: 8px;
   font: var(--font-secondary);
-  float: left;
 }
 
 /* Base */
 
-.a-toggle--shape {
+.a-toggle__shape {
+  display: inline-block;
   position: relative;
-  float: left;
+  vertical-align: middle;
   cursor: pointer;
 }
 
-.a-toggle--shape::before {
+.a-toggle__shape::before {
   display: block;
   width: var(--toggle-base-width);
   height: var(--toggle-base-height);
@@ -51,7 +51,7 @@
 
 /* Circle */
 
-.a-toggle--shape::after {
+.a-toggle__shape::after {
   position: absolute;
   top: 1px;
   left: 1px;
@@ -67,35 +67,35 @@
 
 /* On state */
 
-.a-toggle input[type='checkbox']:checked ~ .a-toggle--shape::before {
+.a-toggle > input[type='checkbox']:checked ~ .a-toggle__shape::before {
   background-color: var(--color-uranus-500);
 }
 
-.a-toggle input[type='checkbox']:checked ~ .a-toggle--shape::after {
+.a-toggle > input[type='checkbox']:checked ~ .a-toggle__shape::after {
   top: 1px;
   left: 21px;
 }
 
 /* Disabled state */
 
-.a-toggle input[type='checkbox']:disabled ~ .a-toggle--shape::before {
+.a-toggle > input[type='checkbox']:disabled ~ .a-toggle__shape::before {
   background-color: var(--color-moon-200);
 }
 
 .a-toggle--disabled label,
-.a-toggle input[type='checkbox']:disabled {
+.a-toggle > input[type='checkbox']:disabled {
   cursor: not-allowed;
   color: var(--color-moon-200);
 }
 
 /* Hover state on */
 
-.a-toggle input[type='checkbox']:not(:disabled):hover ~ .a-toggle--shape::before {
+.a-toggle > input[type='checkbox']:not(:disabled):hover ~ .a-toggle__shape::before {
   background-color: var(--color-uranus-400);
 }
 
 /* Hover state off */
 
-.a-toggle input[type='checkbox']:not(:checked):not(:disabled):hover ~ .a-toggle--shape::before {
+.a-toggle > input[type='checkbox']:not(:checked):not(:disabled):hover ~ .a-toggle__shape::before {
   background-color: var(--color-moon-300);
 }

--- a/src/css/toggle.css
+++ b/src/css/toggle.css
@@ -6,30 +6,41 @@
   --toggle-circle-size: 28px;
 
   display: inline-block;
+  position: relative;
 }
 
 /* Hide standard input */
 
-.a-toggle > input[type='checkbox'] {
-  position: relative;
-  visibility: hidden;
-  width: var(--toggle-base-width);
+.a-toggle input[type='checkbox'] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
   height: var(--toggle-base-height);
   vertical-align: middle;
+  opacity: 0;
+  cursor: pointer;
+  z-index: var(--z-index-1);
 }
 
 /* Label */
 
-.a-toggle > label {
+.a-toggle label {
   padding-right: 8px;
   font: var(--font-secondary);
+  float: left;
 }
 
 /* Base */
 
-.a-toggle > input[type='checkbox']::before {
+.a-toggle--shape {
+  position: relative;
+  float: left;
+  cursor: pointer;
+}
+
+.a-toggle--shape::before {
   display: block;
-  visibility: visible;
   width: var(--toggle-base-width);
   height: var(--toggle-base-height);
   content: '';
@@ -40,7 +51,7 @@
 
 /* Circle */
 
-.a-toggle > input[type='checkbox']::after {
+.a-toggle--shape::after {
   position: absolute;
   top: 1px;
   left: 1px;
@@ -56,42 +67,35 @@
 
 /* On state */
 
-.a-toggle > input[type='checkbox']:checked::before {
+.a-toggle input[type='checkbox']:checked ~ .a-toggle--shape::before {
   background-color: var(--color-uranus-500);
 }
 
-.a-toggle > input[type='checkbox']:checked::after {
+.a-toggle input[type='checkbox']:checked ~ .a-toggle--shape::after {
   top: 1px;
   left: 21px;
 }
 
 /* Disabled state */
 
-.a-toggle > input[type='checkbox']:disabled::before {
+.a-toggle input[type='checkbox']:disabled ~ .a-toggle--shape::before {
   background-color: var(--color-moon-200);
 }
 
-.a-toggle--disabled > label,
-.a-toggle > input[type='checkbox']:disabled {
+.a-toggle--disabled label,
+.a-toggle input[type='checkbox']:disabled {
   cursor: not-allowed;
   color: var(--color-moon-200);
 }
 
 /* Hover state on */
 
-.a-toggle > input[type='checkbox']:not(:disabled):hover::before {
+.a-toggle input[type='checkbox']:not(:disabled):hover ~ .a-toggle--shape::before {
   background-color: var(--color-uranus-400);
 }
 
 /* Hover state off */
 
-.a-toggle > input[type='checkbox']:not(:checked):not(:disabled):hover::before {
+.a-toggle input[type='checkbox']:not(:checked):not(:disabled):hover ~ .a-toggle--shape::before {
   background-color: var(--color-moon-300);
-}
-
-/* Cursor */
-
-.a-toggle:not(.a-toggle--disabled) > label:hover,
-.a-toggle > input[type='checkbox']:not(:disabled):hover {
-  cursor: pointer;
 }


### PR DESCRIPTION
# What

Refactor radio, checkbox, toggle and slider components in Controls & Toggles to make them work in all browsers.

# Why

There was an issue report stating that these components did not work in Firefox, because only Chrome accepts pseudoclasses on `input` tags.

# How

* Remove styles from the `input` tag, using it only to handle behavior now;
* Create a new sibling `div` to draw the component shape (this must be after the `input` in the markup order, to make selection possible when handling states);
* Adjust CSS accordingly.
