### PR TITLE
Improve instructions for font installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run `yarn add @magnetis/astro` or `npm install @magnetis/astro`.
 ### Adding Astro fonts (important!)
 
 After you've imported Astro, you still need to add our fonts to your project manually.
-You can get the updated font links either in the [Astro's Typography page](https://astro.magnetis.com.br/#/docs-typography) or inside the project folder in `public/docz.html`.
+You can get the updated font links either in the [Typography page](https://astro.magnetis.com.br/#/docs-typography) or inside the project folder in `public/docz.html`.
 
 ## Using Astro
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run `yarn add @magnetis/astro` or `npm install @magnetis/astro`.
 ### Adding Astro fonts (important!)
 
 After you've imported Astro, you still need to add our fonts to your project manually.
-You can get the updated font links either in the Typography page at [astro.magnetis.com.br](https://astro.magnetis.com.br/) or inside the project folder in `public/docz.html`.
+You can get the updated font links either in the [Astro's Typography page](https://astro.magnetis.com.br/#/docs-typography) or inside the project folder in `public/docz.html`.
 
 ## Using Astro
 


### PR DESCRIPTION
# What

On the font installation I propose pointing the users directly to the Typography page where the `download font` button is immediately visible as opposed to redirecting them to the Landing page where they still need to navigate to the Typography section to find the fonts.

# Why

This creates a better experience for people using Astro for the first time, as it makes it easier for them to find the Fonts to download.

# How

Pointing them directly to the Typography page removes one extra step for getting started with the framework, and therefore makes it slightly simpler.

