### PR TITLE
Adjust focus behavior on components

### DIFF
--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -276,23 +276,27 @@ For inline links in paragraphs and informative texts. Regular links navigate to 
 
 If you're looking for buttons in `<a>` tags, see "buttons in `<a>` elements" below.
 
+We recommend you add the attribute `tabIndex="0"` to make the link focusable via keyboard.
+
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <a className='a-link'>inline link</a>
+  <a className='a-link' tabIndex='0'>inline link</a>
 </Playground>
 
 ## buttons in `<a>` elements
 
 Although button classes are designed for `<button>` elements, you may also use them with `<a>` elements when semantically recommended. Note that some browsers may render them slightly differently.
 
-`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `a-btn--disabled` class like the example below.
+`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `a-btn--disabled` class like the example below. 
+
+We also recommend you add the attribute `tabIndex="0"` to make the button focusable via keyboard.
 
 If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
 
 <Playground>
-  <a className='a-btn a-btn--uranus a-btn--medium'>link button</a>
-  <a className='a-btn a-btn--uranus a-btn--medium a-btn--disabled'>
+  <a className='a-btn a-btn--uranus a-btn--medium' tabIndex='0'>link button</a>
+  <a className='a-btn a-btn--uranus a-btn--medium a-btn--disabled' tabIndex='0'>
     link button disabled
   </a>
 </Playground>

--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -276,8 +276,6 @@ For inline links in paragraphs and informative texts. Regular links navigate to 
 
 If you're looking for buttons in `<a>` tags, see "buttons in `<a>` elements" below.
 
-We recommend you add the attribute `tabIndex="0"` to make the link focusable via keyboard.
-
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
@@ -289,8 +287,6 @@ Mouseover and click to view `:hover` and `:active` states.
 Although button classes are designed for `<button>` elements, you may also use them with `<a>` elements when semantically recommended. Note that some browsers may render them slightly differently.
 
 `<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `a-btn--disabled` class like the example below. 
-
-We also recommend you add the attribute `tabIndex="0"` to make the button focusable via keyboard.
 
 If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
 

--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -286,7 +286,7 @@ Mouseover and click to view `:hover` and `:active` states.
 
 Although button classes are designed for `<button>` elements, you may also use them with `<a>` elements when semantically recommended. Note that some browsers may render them slightly differently.
 
-`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `a-btn--disabled` class like the example below. 
+`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `a-btn--disabled` class like the example below.
 
 If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
 

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -26,25 +26,3 @@ ul {
   list-style: none;
   padding: 0;
 }
-
-.a-link {
-  font: var(--font-primary);
-  font-size: 18px;
-  font-weight: 500;
-  color: var(--color-uranus-700);
-  text-decoration: underline;
-  cursor: pointer;
-  word-wrap: break-word;
-}
-
-.a-link:hover {
-  color: var(--color-uranus-500);
-}
-
-.a-link:active {
-  color: var(--color-uranus-800);
-}
-
-a.a-btn {
-  text-decoration: none;
-}

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -432,3 +432,27 @@
 .a-btn--icon.a-btn--large {
   padding: 11px 9px;
 }
+
+/* Inline link */
+
+.a-link {
+  font: var(--font-primary);
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--color-uranus-700);
+  text-decoration: underline;
+  cursor: pointer;
+  word-wrap: break-word;
+}
+
+.a-link:hover {
+  color: var(--color-uranus-500);
+}
+
+.a-link:active {
+  color: var(--color-uranus-800);
+}
+
+a.a-btn {
+  text-decoration: none;
+}

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -20,6 +20,10 @@
   color: var(--color-space-100);
 }
 
+.a-btn:focus {
+  outline: none;
+}
+
 /* Button color modifiers */
 
 .a-btn--uranus {
@@ -28,9 +32,10 @@
   color: var(--color-space-100);
 }
 
-.a-btn--uranus:hover:not(:disabled):not(.a-btn--disabled) {
-  background-color: var(--color-uranus-400);
-  border-color: var(--color-uranus-400);
+.a-btn--uranus:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--uranus:focus:not(:disabled):not(.a-btn--disabled) {
+  background-color: var(--color-uranus-300);
+  border-color: var(--color-uranus-300);
 }
 
 .a-btn--uranus:active:not(:disabled):not(.a-btn--disabled) {
@@ -44,9 +49,10 @@
   color: var(--color-space-100);
 }
 
-.a-btn--venus:hover:not(:disabled):not(.a-btn--disabled) {
-  background-color: var(--color-venus-300);
-  border-color: var(--color-venus-300);
+.a-btn--venus:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--venus:focus:not(:disabled):not(.a-btn--disabled) {
+  background-color: var(--color-venus-200);
+  border-color: var(--color-venus-200);
 }
 
 .a-btn--venus:active:not(:disabled):not(.a-btn--disabled) {
@@ -60,9 +66,10 @@
   color: var(--color-space-100);
 }
 
-.a-btn--mars:hover:not(:disabled):not(.a-btn--disabled) {
-  background-color: var(--color-mars-400);
-  border-color: var(--color-mars-400);
+.a-btn--mars:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--mars:focus:not(:disabled):not(.a-btn--disabled) {
+  background-color: var(--color-mars-300);
+  border-color: var(--color-mars-300);
 }
 
 .a-btn--mars:active:not(:disabled):not(.a-btn--disabled) {
@@ -76,9 +83,10 @@
   color: var(--color-moon-900);
 }
 
-.a-btn--earth:hover:not(:disabled):not(.a-btn--disabled) {
-  background-color: var(--color-earth-300);
-  border-color: var(--color-earth-300);
+.a-btn--earth:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--earth:focus:not(:disabled):not(.a-btn--disabled) {
+  background-color: var(--color-earth-200);
+  border-color: var(--color-earth-200);
 }
 
 .a-btn--earth:active:not(:disabled):not(.a-btn--disabled) {
@@ -94,7 +102,8 @@
   color: var(--color-uranus-500);
 }
 
-.a-btn--outline-uranus:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--outline-uranus:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--outline-uranus:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-uranus-400);
   border-color: var(--color-uranus-400);
   color: var(--color-space-100);
@@ -112,7 +121,8 @@
   color: var(--color-venus-400);
 }
 
-.a-btn--outline-venus:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--outline-venus:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--outline-venus:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-venus-300);
   border-color: var(--color-venus-300);
   color: var(--color-space-100);
@@ -130,7 +140,8 @@
   color: var(--color-earth-600);
 }
 
-.a-btn--outline-earth:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--outline-earth:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--outline-earth:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-earth-300);
   border-color: var(--color-earth-300);
   color: var(--color-moon-900);
@@ -148,7 +159,8 @@
   color: var(--color-mars-500);
 }
 
-.a-btn--outline-mars:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--outline-mars:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--outline-mars:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-mars-400);
   border-color: var(--color-mars-400);
   color: var(--color-space-100);
@@ -186,7 +198,8 @@
   color: var(--color-uranus-500);
 }
 
-.a-btn--ghost-uranus:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--ghost-uranus:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--ghost-uranus:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-uranus-400);
@@ -204,7 +217,8 @@
   color: var(--color-venus-400);
 }
 
-.a-btn--ghost-venus:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--ghost-venus:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--ghost-venus:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-venus-300);
@@ -222,7 +236,8 @@
   color: var(--color-earth-600);
 }
 
-.a-btn--ghost-earth:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--ghost-earth:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--ghost-earth:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-earth-300);
@@ -240,7 +255,8 @@
   color: var(--color-mars-500);
 }
 
-.a-btn--ghost-mars:hover:not(:disabled):not(.a-btn--disabled) {
+.a-btn--ghost-mars:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--ghost-mars:focus:not(:disabled):not(.a-btn--disabled) {
   background-color: var(--color-moon-100);
   border-color: var(--color-moon-100);
   color: var(--color-mars-400);
@@ -315,12 +331,16 @@
 .a-btn--outline-mars:hover:not(:disabled):not(.a-btn--disabled) .a-icon,
 .a-btn--outline-uranus:active:not(:disabled):not(.a-btn--disabled) .a-icon,
 .a-btn--outline-venus:active:not(:disabled):not(.a-btn--disabled) .a-icon,
-.a-btn--outline-mars:active:not(:disabled):not(.a-btn--disabled) .a-icon {
+.a-btn--outline-mars:active:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--outline-uranus:focus:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--outline-venus:focus:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--outline-mars:focus:not(:disabled):not(.a-btn--disabled) .a-icon {
   background-color: var(--color-space-100);
 }
 
 .a-btn--outline-earth:hover:not(:disabled):not(.a-btn--disabled) .a-icon,
-.a-btn--outline-earth:active:not(:disabled):not(.a-btn--disabled) .a-icon {
+.a-btn--outline-earth:active:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--outline-earth:focus:not(:disabled):not(.a-btn--disabled) .a-icon {
   background-color: var(--color-moon-900);
 }
 
@@ -341,7 +361,8 @@
   background-color: var(--color-uranus-500);
 }
 
-.a-btn--ghost-uranus:hover:not(:disabled):not(.a-btn--disabled) .a-icon {
+.a-btn--ghost-uranus:hover:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--ghost-uranus:focus:not(:disabled):not(.a-btn--disabled) .a-icon {
   background-color: var(--color-uranus-400);
 }
 
@@ -353,7 +374,8 @@
   background-color: var(--color-venus-400);
 }
 
-.a-btn--ghost-venus:hover:not(:disabled):not(.a-btn--disabled) .a-icon {
+.a-btn--ghost-venus:hover:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--ghost-venus:focus:not(:disabled):not(.a-btn--disabled) .a-icon {
   background-color: var(--color-venus-300);
 }
 
@@ -365,7 +387,8 @@
   background-color: var(--color-earth-600);
 }
 
-.a-btn--ghost-earth:hover:not(:disabled):not(.a-btn--disabled) .a-icon {
+.a-btn--ghost-earth:hover:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--ghost-earth:focus:not(:disabled):not(.a-btn--disabled) .a-icon {
   background-color: var(--color-earth-300);
 }
 
@@ -377,7 +400,8 @@
   background-color: var(--color-mars-500);
 }
 
-.a-btn--ghost-mars:hover:not(:disabled):not(.a-btn--disabled) .a-icon {
+.a-btn--ghost-mars:hover:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--ghost-mars:focus:not(:disabled):not(.a-btn--disabled) .a-icon {
   background-color: var(--color-mars-400);
 }
 

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -477,6 +477,11 @@
   color: var(--color-uranus-800);
 }
 
+.a-link:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(21, 156, 228, 0.4);
+}
+
 a.a-btn {
   text-decoration: none;
 }

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -62,6 +62,10 @@
   background-color: var(--color-moon-200);
 }
 
+.a-checkbox > input[type='checkbox']:focus ~ .a-checkbox__shape::before {
+  box-shadow: 0 0 0 3px rgba(21, 156, 228, 0.4);
+}
+
 .a-checkbox > input[type='checkbox']:checked ~ .a-checkbox__shape::before {
   border-color: var(--color-uranus-500);
   background-color: var(--color-uranus-500);

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -59,6 +59,7 @@
 
 .a-input > input:focus,
 .a-input > textarea:focus {
+  outline: none;
   border: 1px solid var(--color-uranus-500);
 }
 

--- a/src/css/radio.css
+++ b/src/css/radio.css
@@ -74,6 +74,12 @@
   border-color: var(--color-moon-200);
 }
 
+/* Focus state */
+
+.a-radio > input[type='radio']:focus ~ .a-radio__shape::before {
+  box-shadow: 0 0 0 3px rgba(21, 156, 228, 0.4);
+}
+
 /* Hover state on */
 
 .a-radio > input[type='radio']:not(:disabled):hover ~ .a-radio__shape::before {

--- a/src/css/slider.css
+++ b/src/css/slider.css
@@ -64,7 +64,8 @@
   transition: all 0.3s ease;
 }
 
-.a-slider > input[type='range']:not(:disabled)::-webkit-slider-thumb:hover {
+.a-slider > input[type='range']:not(:disabled)::-webkit-slider-thumb:hover,
+.a-slider > input[type='range']:focus::-webkit-slider-thumb {
   width: 16px;
   height: 16px;
   box-shadow: 0 0 0 4px var(--color-uranus-300);

--- a/src/css/tabs.css
+++ b/src/css/tabs.css
@@ -69,6 +69,12 @@
   display: block;
 }
 
+/* Focus state */
+
+.a-tabs > .a-tabs__item:focus + .a-tabs__label {
+  box-shadow: 0 0 0 3px rgba(21, 156, 228, 0.4);
+}
+
 /* Active state */
 
 .a-tabs > .a-tabs__item:checked + .a-tabs__label {

--- a/src/css/toggle.css
+++ b/src/css/toggle.css
@@ -88,6 +88,12 @@
   color: var(--color-moon-200);
 }
 
+/* Focus state */
+
+.a-toggle > input[type='checkbox']:focus ~ .a-toggle__shape::before {
+  box-shadow: 0 0 0 3px rgba(21, 156, 228, 0.4);
+}
+
 /* Hover state on */
 
 .a-toggle > input[type='checkbox']:not(:disabled):hover ~ .a-toggle__shape::before {


### PR DESCRIPTION
# What

Adjust the focus behavior on all components to make them accessible via keyboard _and_ better looking at the same time.

# Why

Some components had the default outline focus style from the browser, and some had their inputs hidden and were drawn on pseudo-elements, which made them un-focusable (because focus happens on the input tag).
We needed all components to be accessible via keyboard.

# How

- Remove link and link button styles from `base.css` and place them in `buttons.css`, since they're explained in the Buttons doc page.
- Button focus: apply the same style as the hover state, an elegant solution to "remove" the focus outline while still keeping them focusable via keyboard. Also lighten the hover/focus colors for the primary buttons to get more contrast.
- Checkbox, radio, tabs & toggle focus: add a box-shadow focus style to the pseudo-element shape when the input is focused.
- Slider focus: apply the same style as the hover state to the thumb circle when it's focused.
- Input focus: just remove the default browser outline, as we already have our own effect by coloring the border of the input when it's focused.
- Add an accessibility hint to the Buttons doc page, advising users to add a `tabindex` when creating buttons with `<a>` elements, since they're un-focusable by default.