### PR TITLE
Fix input label color inconsistency

### DIFF
--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -21,12 +21,12 @@
   left: 16px;
   transition: 0.2s ease all;
   pointer-events: none;
-  color: var(--color-moon-300);
+  color: var(--color-moon-400);
   font: var(--font-secondary);
 }
 
 .a-input > input::placeholder {
-  color: var(--color-moon-300);
+  color: var(--color-moon-400);
 }
 
 .a-input--messaging {
@@ -46,7 +46,7 @@
 }
 
 .a-input--validated > label {
-  color: var(--color-moon-300);
+  color: var(--color-moon-400);
 }
 
 .a-input--invalid > input {


### PR DESCRIPTION
# What

Fix input label color inconsistency.

# Why

In our docs, input label color is always moon 300. But according to the specs, when the label floats, it should change to moon 500.

# How

As there's a complex conflict between the need to set a color for the floating label and the need to keep the invalid label red at all times (selector specificity was getting crazy), we agreed with the design team to set one standard grey for all states.
The label is now moon 400 when resting _and_ floating.

# Sample

**Before** | **After**
-|-
<img width="802" alt="Screen Shot 2019-04-22 at 14 14 27" src="https://user-images.githubusercontent.com/25252211/56513603-5d8acf80-6509-11e9-9752-8ced24c08128.png">|<img width="757" alt="Screen Shot 2019-04-22 at 14 14 08" src="https://user-images.githubusercontent.com/25252211/56513602-5c59a280-6509-11e9-8be0-d2b423b24518.png">

