### PR TITLE
Remove Flexbox Grid system from project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "node"
-  - "lts/*"
+  - '11'
 install:
-  - yarn global add postcss-cli
   - yarn
 script: yarn ci:build

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Here's a quick example. If you'd like to create a Display text styled in Astro t
 
 6. If your styles aren't rendered correctly, make sure Astro has been successfully installed into your project tree and `astro.css` is correctly imported.
 
-When building layout structures, don't forget to use [Flexbox Grid](https://github.com/kristoferjoseph/flexboxgrid), which is already built in your project as an Astro dependency.
-
 ## Contributing
 
 It's awesome that you want to contribute to Astro! Please see [CONTRIBUTING.md](CONTRIBUTING.md) to learn how it works.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ci:build": "yarn run build && yarn run lint:css"
   },
   "dependencies": {
-    "flexboxgrid": "^6.3.1",
     "normalize.css": "^8.0.0"
   },
   "devDependencies": {

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,4 @@
 @import '../node_modules/normalize.css/normalize.css';
-@import '../node_modules/flexboxgrid/dist/flexboxgrid.min.css';
 @import './css/colors.css';
 @import './css/gradients.css';
 @import './css/z-index.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,10 +4081,6 @@ flatted@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
 
-flexboxgrid@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/flexboxgrid/-/flexboxgrid-6.3.1.tgz#e99898afc07b7047722bb81a958a5fba4d4e20fd"
-
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"


### PR DESCRIPTION
# What

This PR removes [Flexbox Grid](http://flexboxgrid.com) from the Astro project.

# Why

So far we haven't made use of this lib. Besides that, we received reports of some generic classes (eg `.row`) causing some conflicts.

# How

* Uninstall and remove `flexboxgrid` reference from `package.json` and `yarn.lock` files
* Remove lib reference from README

# Refs

* [Trello card](https://trello.com/c/Z8Dj1kLT)
* [Clubhouse card](https://app.clubhouse.io/mag-openaccount/story/5428/remover-a-dependência-flexboxgrid) (ch5428)