### PR TITLE
Create ghost inputs and add them to Inputs

### DIFF
--- a/docs/inputs.mdx
+++ b/docs/inputs.mdx
@@ -86,6 +86,32 @@ Text areas are used in contexts that demand long and descriptive texts.
   </div>
 </Playground>
 
+## ghost inputs
+
+Ghost inputs are used in the foreground of colorful backgrounds or images, always displayed in white color in order to preserve good usability and legibility. Depending on the context, when the user starts typing, a white icon might appear on the right side of the component, fading in.
+
+This input style does not have a disabled state.
+
+<Playground className='two-columns gradient-bg'>
+  <div className='a-input a-input--ghost'>
+    <input id='ghost1' type='text' aria-labelledby='ghostlabel1' />
+    <label id='ghostlabel1' htmlFor='ghost1'>
+      Standard
+    </label>
+  </div>
+  <div className='a-input a-input--ghost a-input--validated'>
+    <input
+      id='ghost2'
+      type='text'
+      aria-labelledby='ghostlabel2'
+      defaultValue='Astro Team'
+    />
+    <label id='ghostlabel2' htmlFor='ghost2'>
+      Validated
+    </label>
+  </div>
+</Playground>
+
 ## messaging inputs
 
 Inputs used for messaging and similar contexts. They carry embedded [icon buttons](/docs-buttons#icon-buttons) that send the data,

--- a/doczrc.js
+++ b/doczrc.js
@@ -254,6 +254,9 @@ export default {
         '&.two-columns': {
           display: 'inline-grid',
           gridTemplateColumns: 'auto auto'
+        },
+        '&.gradient-bg': {
+          backgroundImage: 'var(--gradient-andromeda)'
         }
       }
     }

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -1,3 +1,5 @@
+/* stylelint-disable no-descending-specificity */
+
 .a-input {
   position: relative;
   display: flex;

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -141,3 +141,30 @@
   color: var(--color-moon-300);
   font: var(--font-secondary);
 }
+
+/* Ghost inputs */
+
+.a-input--ghost > input,
+.a-input--ghost > input:focus,
+.a-input--ghost.a-input--validated > input,
+.a-input--ghost.a-input--validated > input:focus,
+.a-input--ghost.a-input--invalid > input {
+  border: 1px solid var(--color-space-100);
+  background-color: transparent;
+  color: var(--color-space-100);
+}
+
+.a-input--ghost > label,
+.a-input--ghost > input:focus + label,
+.a-input--ghost.a-input > input::placeholder,
+.a-input--ghost.a-input--validated > label,
+.a-input--ghost.a-input--validated > input:focus + label,
+.a-input--ghost.a-input--invalid > label,
+.a-input--ghost.a-input > .a-input__error {
+  color: var(--color-space-100);
+}
+
+.a-input--ghost.a-input--validated::after,
+.a-input--ghost.a-input--invalid::after {
+  background-color: var(--color-space-100);
+}


### PR DESCRIPTION
# What

Create ghost input components and add them to the Inputs page on the docs.

# Why

We have design specs for that input style.

# How

- Create styles for the ghost inputs in `inputs.css`;
- Create a class to add a gradient background to the Playground component in the themeConfig object in `doczrc.js` file;
- Add a sample of the component in the Inputs doc page;
- Absolutely had to disable the Stylelint rule for the CSS file, else I'd have to scatter the ghost input styles in different places in the file. Will reorganize the whole file later, since it's all scattered because of that rule 😬 

# Sample

<img width="775" alt="Screen Shot 2019-04-25 at 16 22 02" src="https://user-images.githubusercontent.com/25252211/56762459-48ff3f00-6776-11e9-9c8e-55df7bf5e034.png">
