### PR TITLE
Fix label leaking on tabs component (issue #82)

### DIFF
--- a/src/css/tabs.css
+++ b/src/css/tabs.css
@@ -32,7 +32,7 @@
   display: flex;
   width: 100%;
   min-height: 40px;
-  margin-top: 4px;
+  margin: 4px 0;
   padding: 8px 32px;
   transition: background-color 0.3s ease, color 0.3s ease;
   text-align: center;


### PR DESCRIPTION
# What

This PR resolve #82 issue. _Tabs labels are leaking from it's container_.

# Why

Astro's devs should render all components without bugs or workarounds.

# How

* Apply bottom margin on tab labels.

# Sample

| Before fix | After fix |
| --- | --- |
| ![56921563-76acf680-6a9c-11e9-89b2-51389b1aae8e](https://user-images.githubusercontent.com/1002072/56968435-87f81080-6b39-11e9-86ad-c525634faee1.png) | <img width="714" alt="Captura de Tela 2019-04-30 às 11 00 31" src="https://user-images.githubusercontent.com/1002072/56968495-9cd4a400-6b39-11e9-9a57-53f765ff0483.png"> |

# Refs

* [Trello's task](https://trello.com/b/nKubob3S/astro)
* Clubhouse's tasks: ch6285 ch6286