### PR TITLE
Create different input size

### DIFF
--- a/docs/inputs.mdx
+++ b/docs/inputs.mdx
@@ -247,3 +247,104 @@ To create the disabled state, add the `a-input--disabled` modifier class on elem
 </Playground>
 
 <HandleInputEvents />
+
+## sizes
+
+Inputs can be used in different sizes depending on the context.
+
+To create the large size variation, add the `a-input--large` modifier class on element root.
+
+<Playground className='two-columns'>
+  {/* Standard inputs */}
+  <div className='a-input'>
+    <input id='inputmedium' type='text' aria-labelledby='labelmedium' />
+    <label id='labelmedium' htmlFor='inputmedium'>
+      Standard medium
+    </label>
+  </div>
+  <div className='a-input a-input--large'>
+    <input id='inputlarge' type='text' aria-labelledby='labellarge' />
+    <label id='labellarge' htmlFor='inputlarge'>
+      Standard large
+    </label>
+  </div>
+  {/* Mask inputs */}
+  <div className='a-input'>
+    <input
+      id='inputdatemedium'
+      type='text'
+      placeholder='DD/MM/YYYY'
+      aria-labelledby='labeldatemedium'
+    />
+    <label id='labeldatemedium' htmlFor='inputdatemedium'>
+      Date medium
+    </label>
+  </div>
+  <div className='a-input a-input--large'>
+    <input
+      id='inputdatelarge'
+      type='text'
+      placeholder='DD/MM/YYYY'
+      aria-labelledby='labeldatelarge'
+    />
+    <label id='labeldatelarge' htmlFor='inputdatelarge'>
+      Date large
+    </label>
+  </div>
+  {/* Control inputs */}
+  <div className='a-input a-input--control'>
+    <input
+      id='inputcontrolmedium'
+      type='text'
+      data-step='100'
+      defaultValue='0,00'
+      placeholder='0,00'
+      aria-labelledby='labelcontrolmedium'
+    />
+    <label id='labelcontrolmedium' htmlFor='inputcontrolmedium'>
+      Control input medium (R$)
+    </label>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__decrement'>
+      <i className='a-icon a-icon__input-dash a-icon--size-small' />
+    </button>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__increment'>
+      <i className='a-icon a-icon__input-plus a-icon--size-small' />
+    </button>
+  </div>
+  <div className='a-input a-input--control a-input--large'>
+    <input
+      id='inputcontrollarge'
+      type='text'
+      data-step='100'
+      defaultValue='0,00'
+      placeholder='0,00'
+      aria-labelledby='labelcontrollarge'
+    />
+    <label id='labelcontrollarge' htmlFor='inputcontrollarge'>
+      Control input large (R$)
+    </label>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__decrement'>
+      <i className='a-icon a-icon__input-dash a-icon--size-small' />
+    </button>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__increment'>
+      <i className='a-icon a-icon__input-plus a-icon--size-small' />
+    </button>
+  </div>
+  {/* Messaging inputs */}
+  <div className='a-input a-input--messaging'>
+    <input
+      id='inputmessagingmedium'
+      type='text'
+      placeholder='Messaging medium'
+    />
+    <button className='a-btn a-btn--uranus a-btn--medium a-btn--icon' disabled>
+      <i className='a-icon a-icon__arrow-right a-icon--size-medium' />
+    </button>
+  </div>
+  <div className='a-input a-input--messaging a-input--large'>
+    <input id='inputmessaginglarge' type='text' placeholder='Messaging large' />
+    <button className='a-btn a-btn--uranus a-btn--medium a-btn--icon' disabled>
+      <i className='a-icon a-icon__arrow-right a-icon--size-medium' />
+    </button>
+  </div>
+</Playground>

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -218,3 +218,65 @@
   color: var(--color-moon-300);
   font: var(--font-secondary);
 }
+
+/* Large size */
+
+/* Large: fonts */
+
+.a-input--large > label,
+.a-input--large > input {
+  font-size: 24px;
+}
+
+/* Large: inputs */
+
+.a-input--large > input {
+  padding-right: 24px;
+  padding-left: 24px;
+}
+
+/* Large: labels */
+
+.a-input--large > label {
+  left: 24px;
+}
+
+.a-input--large .a-input--floating-label,
+.a-input--large > input:focus + label {
+  top: 6px;
+  font-size: 16px;
+}
+
+/* Large: validation inputs */
+
+.a-input--large.a-input--validated > input,
+.a-input--large.a-input--invalid > input {
+  padding-right: 56px;
+}
+
+.a-input--large.a-input--validated::after,
+.a-input--large.a-input--invalid::after {
+  top: 18px;
+}
+
+/* Large: control inputs */
+
+.a-input--large.a-input--control > input {
+  padding-right: 96px;
+}
+
+.a-input--large.a-input--control .a-btn {
+  top: 18px;
+}
+
+/* Large: message inputs */
+
+.a-input--large.a-input--messaging .a-btn {
+  width: 54px;
+  height: 54px;
+  border-radius: 54px;
+}
+
+.a-input--large.a-input--messaging .a-icon {
+  font-size: 34px;
+}

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -274,7 +274,7 @@
 .a-input--large.a-input--messaging .a-btn {
   width: 54px;
   height: 54px;
-  border-radius: 54px;
+  border-radius: 50%;
 }
 
 .a-input--large.a-input--messaging .a-icon {


### PR DESCRIPTION
# What

This PR adds a large size to all input texts.

# Why

To allow some users to have a better experience and more accessibility.

# How

* Add `.a-input--large` modifier
* Apply some adjustments in different input types
* Update the docs with this new possibility

# Sample

<img width="779" alt="Captura de Tela 2019-05-09 às 11 21 31" src="https://user-images.githubusercontent.com/1002072/57461026-a605f500-724c-11e9-8ecc-f0594e3e6333.png">

# Refs

* [Trello card](https://trello.com/b/nKubob3S/astro)
* [Astro docs](https://projects.invisionapp.com/d/main#/console/14553509/342426782/preview)