### PR TITLE
Change background to transparent on outline and ghost buttons

### DIFF
--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -193,8 +193,8 @@
 /* Ghost button */
 
 .a-btn--ghost-uranus {
-  background-color: var(--color-space-100);
-  border: 2px solid var(--color-space-100);
+  background-color: transparent;
+  border: 2px solid transparent;
   color: var(--color-uranus-500);
 }
 
@@ -212,8 +212,8 @@
 }
 
 .a-btn--ghost-venus {
-  background-color: var(--color-space-100);
-  border: 2px solid var(--color-space-100);
+  background-color: transparent;
+  border: 2px solid transparent;
   color: var(--color-venus-400);
 }
 
@@ -231,8 +231,8 @@
 }
 
 .a-btn--ghost-earth {
-  background-color: var(--color-space-100);
-  border: 2px solid var(--color-space-100);
+  background-color: transparent;
+  border: 2px solid transparent;
   color: var(--color-earth-600);
 }
 
@@ -250,8 +250,8 @@
 }
 
 .a-btn--ghost-mars {
-  background-color: var(--color-space-100);
-  border: 2px solid var(--color-space-100);
+  background-color: transparent;
+  border: 2px solid transparent;
   color: var(--color-mars-500);
 }
 

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -97,7 +97,7 @@
 /* Outline button */
 
 .a-btn--outline-uranus {
-  background-color: var(--color-space-100);
+  background-color: transparent;
   border: 2px solid var(--color-uranus-500);
   color: var(--color-uranus-500);
 }
@@ -116,7 +116,7 @@
 }
 
 .a-btn--outline-venus {
-  background-color: var(--color-space-100);
+  background-color: transparent;
   border: 2px solid var(--color-venus-400);
   color: var(--color-venus-400);
 }
@@ -135,7 +135,7 @@
 }
 
 .a-btn--outline-earth {
-  background-color: var(--color-space-100);
+  background-color: transparent;
   border: 2px solid var(--color-earth-600);
   color: var(--color-earth-600);
 }
@@ -154,7 +154,7 @@
 }
 
 .a-btn--outline-mars {
-  background-color: var(--color-space-100);
+  background-color: transparent;
   border: 2px solid var(--color-mars-500);
   color: var(--color-mars-500);
 }


### PR DESCRIPTION
# What

This __PR__ changes the background of outline and ghost buttons to transparent. 

# Why

Because in others backgrounds without being white, the behavior is kind weird.

# How

* Change background to transparent on outline buttons;
* Change background to transparent on ghost buttons.

# Sample Outline Buttons

### Before Fix
![Screenshot from 2019-05-15 14-20-33](https://user-images.githubusercontent.com/11283132/57795583-b884a080-771c-11e9-8f0c-f56e27bd2f95.png)

### After Fix
![Screenshot from 2019-05-15 14-20-54](https://user-images.githubusercontent.com/11283132/57795582-b884a080-771c-11e9-961f-a3144553e3c2.png)

# Sample Ghost Buttons

### Before Fix
![Screenshot from 2019-05-15 15-39-29](https://user-images.githubusercontent.com/11283132/57800537-0226b880-7728-11e9-960c-690c4ab584af.png)

### After Fix
![Screenshot from 2019-05-15 15-39-02](https://user-images.githubusercontent.com/11283132/57800538-02bf4f00-7728-11e9-982f-441b3b0d57cd.png)



