### PR TITLE
Add font smoothing to Typography (Chrome)

### DIFF
--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -9,6 +9,7 @@
 .a-text--small {
   font: var(--font-primary);
   color: var(--font-color);
+  -webkit-font-smoothing: antialiased;
 }
 
 .a-text--secondary-large,
@@ -16,6 +17,7 @@
 .a-text--secondary-small {
   font: var(--font-secondary);
   color: var(--font-color);
+  -webkit-font-smoothing: antialiased;
 }
 
 /* Display */

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -10,6 +10,7 @@
   font: var(--font-primary);
   color: var(--font-color);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .a-text--secondary-large,
@@ -18,6 +19,7 @@
   font: var(--font-secondary);
   color: var(--font-color);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* Display */


### PR DESCRIPTION
# What

Add font smoothing to our Typography to make the fonts render better in Chrome.

# Why

Fonts look bolder/heavier than they should on Chrome.
Couldn't find a property that worked on Firefox yet, so this PR only addresses Chrome.

# How

Add `-webkit-font-smoothing: antialised` to typography CSS.
It appears that our prefixer doesn't work with this property, so we had to add `-webkit-`.