### PR TITLE
Refactor links usage and update docs

### DIFF
--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -356,13 +356,18 @@ When creating small or big iconlabel or icon buttons, remember to change the siz
 
 For inline links in paragraphs and informative texts. Regular links navigate to other pages or external content.
 
+To create a link, combine the `a-link` class with an Astro typography class in your markup to apply our link properties over your desired font settings. See example below and the [Typography](/docs-typography) page for detailed usage of typography classes.
+
 If you're looking for buttons in `<a>` tags, see "buttons in `<a>` elements" below.
 
 Mouseover and click to view `:hover` and `:active` states.
 
 <Playground>
-  <a className='a-link' tabIndex='0'>
-    inline link
+  <a className='a-link a-text--medium' tabIndex='0'>
+    primary font - medium size
+  </a>
+  <a className='a-link a-text--secondary-small' tabIndex='0'>
+    secondary font - small size
   </a>
 </Playground>
 

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -460,9 +460,6 @@
 /* Inline link */
 
 .a-link {
-  font: var(--font-primary);
-  font-size: var(--font-size-2base);
-  font-weight: 500;
   color: var(--color-uranus-700);
   text-decoration: underline;
   cursor: pointer;


### PR DESCRIPTION
# What

Refactor links usage to extract font settings and allow combinations with different typography settings.

# Why

Links vary a lot depending on their context, so we can't just pick one setting for all of them like we did previously. Many Astro users had to override our link font styles.

**Warning:** This release will contain breaking changes.

# How

- Remove all font settings from `a-link` class;
- Update the docs to explain how to combine this class with the Astro typography classes.

# Sample

<img width="777" alt="Screen Shot 2019-06-05 at 16 51 46" src="https://user-images.githubusercontent.com/25252211/58985901-b27d5f00-87b2-11e9-9142-82fcbb86b2b4.png">

