### PR TITLE
Fix control input missing button

### DIFF
--- a/src/css/icons.css
+++ b/src/css/icons.css
@@ -256,6 +256,10 @@
   mask-image: url(../../assets/icons/light.svg);
 }
 
+.a-icon__input-dash {
+  mask-image: url(../../assets/icons/input-dash.svg);
+}
+
 .a-icon__input-plus {
   mask-image: url(../../assets/icons/input-plus.svg);
 }


### PR DESCRIPTION
# What

Fix the mystery of the missing Control Input decremental button.

# Why

We realized that, in production, one of the Control Input buttons was missing (the decremental one), replaced with a color block.
In further investigation, the SVG is still in the assets folder, but the class is not in the `icons.css` file. WTF?

# How

Create the class to fix the issue.

# Sample

<img width="334" alt="Screen Shot 2019-06-05 at 17 44 31" src="https://user-images.githubusercontent.com/25252211/58989409-3be45f80-87ba-11e9-88b6-282a0029dbcf.png">

