### PR TITLE
Copy CNAME file during docs deploy process

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const gh = require('gh-pages');
+
+const DIST_PATH = '.docz/dist';
+
+fs.copyFile('CNAME', `${DIST_PATH}/CNAME`, (err) => {
+  if (err) throw err;
+  console.log('CNAME file copied to .docz/dist directory');
+});
+
+gh.publish(DIST_PATH, (err) => {
+  if (err) {
+    console.log('Ops, something went wrong...', err);
+  } else {
+    console.log('Update site [ci skip]!');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "docz:dev": "docz dev",
     "docs:build": "docz build",
-    "docs:publish": "yarn run docs:build && gh-pages --dist .docz/dist --message 'Update site [ci skip]'",
+    "docs:publish": "yarn run docs:build && node deploy",
     "build": "postcss src/index.css -o dist/astro.css && svgo assets/icons/*.svg -o dist/assets/icons",
     "lint:css": "stylelint src/css/**/*.css",
     "ci:build": "yarn run build && yarn run lint:css"


### PR DESCRIPTION
# What

This PR fixes the problem of missing CNAME after deploying Astro docs.

# Why

Accordingly to **WHO - World Health Organization**; it's not healthy to keep copying files manually on GitHub.

# How

Creating a deploy file and using `gh-pages` cli.
