### PR TITLE
Update slider thumb size and add full fill

### DIFF
--- a/docs/controls-toggles.mdx
+++ b/docs/controls-toggles.mdx
@@ -128,6 +128,8 @@ We recommend you set the slider width in the `a-slider` class.
 
 The colored percentage fill and counter label will need JS to work on your project. You may find the code for this working example in our GitHub repository. You can also wrap the slider with a React component or apply other frameworks.
 
+The gradient full fill does not require JS to work, as there is no calculation for what percentage of the slider should be filled. Add the `a-slider--full` class to get that effect.
+
 Mouseover and click to view `:hover` and `:active` state.
 
 To create the disabled state, add the `a-slider--disabled` modifier class on element root and `disabled` attribute on the `<input>` tag.
@@ -140,12 +142,19 @@ To create the disabled state, add the `a-slider--disabled` modifier class on ele
     </label>
     <input type='range' min='1' max='100' id='slider1' />
   </div>
+  <div className='a-slider a-slider--full'>
+    <label htmlFor='slider2'>
+      Full fill
+      <span className='a-slider--value'>50 coins</span>
+    </label>
+    <input type='range' min='1' max='100' id='slider2' />
+  </div>
   <div className='a-slider a-slider--disabled'>
-    <label htmlFor='slider1'>
+    <label htmlFor='slider3'>
       Disabled
       <span className='a-slider--value'>0 coins</span>
     </label>
-    <input type='range' min='1' max='100' id='slider1' disabled />
+    <input type='range' min='1' max='100' id='slider3' disabled />
   </div>
 </Playground>
 

--- a/src/css/slider.css
+++ b/src/css/slider.css
@@ -54,28 +54,30 @@
   align-items: center;
 }
 
+.a-slider.a-slider--full > input[type='range']::-webkit-slider-runnable-track {
+  background-image: var(--gradient-cartwheel);
+}
+
 .a-slider > input[type='range']::-webkit-slider-thumb {
   appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 28px;
+  height: 28px;
   border-radius: 100%;
-  background-color: var(--color-uranus-500);
+  background-color: var(--color-space-100);
+  box-shadow: 0 1px 4px 0 rgba(135, 135, 135, 0.5);
   cursor: pointer;
   transition: all 0.3s ease;
 }
 
 .a-slider > input[type='range']:not(:disabled)::-webkit-slider-thumb:hover,
 .a-slider > input[type='range']:focus::-webkit-slider-thumb {
-  width: 16px;
-  height: 16px;
-  box-shadow: 0 0 0 4px var(--color-uranus-300);
+  width: 36px;
+  height: 36px;
 }
 
 .a-slider > input[type='range']:not(:disabled)::-webkit-slider-thumb:active {
-  width: 20px;
-  height: 20px;
-  box-shadow: 0 0 0 4px var(--color-uranus-300);
-  background-color: var(--color-uranus-400);
+  width: 40px;
+  height: 40px;
 }
 
 .a-slider > input[type='range']:disabled::-webkit-slider-runnable-track {
@@ -105,28 +107,30 @@
   align-items: center;
 }
 
+.a-slider.a-slider--full > input[type='range']::-moz-range-track {
+  background-image: var(--gradient-cartwheel);
+}
+
 .a-slider > input[type='range']::-moz-range-thumb {
   appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 28px;
+  height: 28px;
   border: none;
   border-radius: 100%;
-  background-color: var(--color-uranus-500);
+  background-color: var(--color-space-100);
+  box-shadow: 0 1px 4px 0 rgba(135, 135, 135, 0.5);
   cursor: pointer;
   transition: all 0.3s ease;
 }
 
 .a-slider > input[type='range']:not(:disabled)::-moz-range-thumb:hover {
-  width: 16px;
-  height: 16px;
-  box-shadow: 0 0 0 4px var(--color-uranus-300);
+  width: 36px;
+  height: 36px;
 }
 
 .a-slider > input[type='range']:not(:disabled)::-moz-range-thumb:active {
-  width: 20px;
-  height: 20px;
-  box-shadow: 0 0 0 4px var(--color-uranus-300);
-  background-color: var(--color-uranus-400);
+  width: 40px;
+  height: 40px;
 }
 
 .a-slider > input[type='range']:disabled {
@@ -160,27 +164,29 @@
   align-items: center;
 }
 
+.a-slider.a-slider--full > input[type='range']::-ms-track {
+  background-image: var(--gradient-cartwheel);
+}
+
 .a-slider > input[type='range']::-ms-thumb {
   appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 28px;
+  height: 28px;
   border-radius: 100%;
-  background-color: var(--color-uranus-500);
+  background-color: var(--color-space-100);
+  box-shadow: 0 1px 4px 0 rgba(135, 135, 135, 0.5);
   cursor: pointer;
   transition: all 0.3s ease;
 }
 
 .a-slider > input[type='range']:not(:disabled)::-ms-thumb:hover {
-  width: 16px;
-  height: 16px;
-  box-shadow: 0 0 0 4px var(--color-uranus-300);
+  width: 36px;
+  height: 36px;
 }
 
 .a-slider > input[type='range']:not(:disabled)::-ms-thumb:active {
-  width: 20px;
-  height: 20px;
-  box-shadow: 0 0 0 4px var(--color-uranus-300);
-  background-color: var(--color-uranus-400);
+  width: 40px;
+  height: 40px;
 }
 
 .a-slider > input[type='range']:disabled::-ms-track {


### PR DESCRIPTION
# What

Update slider thumb size to improve touch area in mobile devices;
Add the full fill variant using our gradients.

# Why

Current thumb size is too small to control in a touchscreen.

# How

Update CSS and docs to reflect the changes in all browsers.

# Sample

**Before** | **After**
-|-
<img width="749" alt="Screen Shot 2019-07-03 at 15 19 41" src="https://user-images.githubusercontent.com/25252211/60615832-74219280-9da6-11e9-9c8d-f510093ec32c.png">|<img width="747" alt="Screen Shot 2019-07-03 at 15 22 30" src="https://user-images.githubusercontent.com/25252211/60615834-74219280-9da6-11e9-80e4-142db75a761c.png">

