### PR TITLE
Fix bugs related to input invalid and validated states

### DIFF
--- a/docs/inputs.mdx
+++ b/docs/inputs.mdx
@@ -212,6 +212,45 @@ To create the disabled state, add the `a-input--disabled` modifier class on elem
       <i className='a-icon a-icon__input-plus a-icon--size-small' />
     </button>
   </div>
+  <div className='a-input a-input--control a-input--validated'>
+    <input
+      id='control3'
+      type='text'
+      data-step='100'
+      defaultValue='0,00'
+      placeholder='0,00'
+      aria-labelledby='controllabel3'
+    />
+    <label id='controllabel3' htmlFor='control3'>
+      Control input validated (R$)
+    </label>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__decrement'>
+      <i className='a-icon a-icon__input-dash a-icon--size-small' />
+    </button>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__increment'>
+      <i className='a-icon a-icon__input-plus a-icon--size-small' />
+    </button>
+  </div>
+  <div className='a-input a-input--control a-input--invalid'>
+    <input
+      id='control4'
+      type='text'
+      data-step='100'
+      defaultValue='0,00'
+      placeholder='0,00'
+      aria-labelledby='controllabel4'
+    />
+    <label id='controllabel4' htmlFor='control4'>
+      Control input invalid (R$)
+    </label>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__decrement'>
+      <i className='a-icon a-icon__input-dash a-icon--size-small' />
+    </button>
+    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__increment'>
+      <i className='a-icon a-icon__input-plus a-icon--size-small' />
+    </button>
+    <span className='a-input__error'>Invalid data</span>
+  </div>
 </Playground>
 
 ## messaging inputs

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -141,14 +141,14 @@
 }
 
 .a-input--validated > label {
-  color: var(--color-moon-300);
+  color: var(--color-moon-400);
 }
 
 .a-input--validated > input:focus + label {
   color: var(--color-earth-400);
 }
 
-.a-input--validated::after {
+.a-input--validated:not(.a-input--control)::after {
   position: absolute;
   top: 12px;
   right: 16px;
@@ -166,12 +166,11 @@
   border: 1px solid var(--color-mars-500);
 }
 
-.a-input--invalid > label,
 .a-input--invalid > input:focus + label {
   color: var(--color-mars-500);
 }
 
-.a-input--invalid::after {
+.a-input--invalid:not(.a-input--control)::after {
   position: absolute;
   top: 12px;
   right: 16px;


### PR DESCRIPTION
# What

This __PR__ fix some bugs related to inputs when it has the invalid or validated states. 

# Why

* Invalid state for empty inputs was causing the placeholder to have a color that makes the placeholder looks like its some value instead of an actually placeholder.
* When `.a-input--validated` or `.a-input--invalid` was used at control inputs, the icon related to this two classes was overleaping with its buttons.

# How

* Remove icon from invalid and validated state for control input
* Add examples at docs for invalid and validated control input
* Change `.a-input--validated > label ` (it was the only one with different color)
* Change `.a-input--invalid > label` to have default placeholder color instead of invalid
# Sample

Invalid and validated control input example
<img width="890" alt="Captura de Tela 2019-07-17 às 17 37 07" src="https://user-images.githubusercontent.com/5252760/61410185-33536e80-a8ba-11e9-9708-4c811a263f93.png">

Keeping the `--color-moon-400` color for placeholders even when its invalid
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5252760/61410629-fd62ba00-a8ba-11e9-9f80-c9d38aa36588.gif)

