### PR TITLE
FIx minor layout breaks introduced by PR #137

### DIFF
--- a/docs/theme/index.js
+++ b/docs/theme/index.js
@@ -15,6 +15,7 @@ const selectors = {
   mobileMenu: '& .Sidebar__Wrapper-dMteFe',
   playgroundWrapper: playgroundSelector,
   playgroundChildrens: `${playgroundSelector} > div`,
+  headerTitle: '& .H1-ecIwba',
 
   /* Docz default elements (hidden) */
 
@@ -25,12 +26,14 @@ const selectors = {
   menuBlueTop: '& .Logo__Wrapper-bzwKYh:before',
   menuItemsBorder: '& .MenuLink__Wrapper-bIIltX:after',
   menuSubitemsBorder: '& .MenuLink__Wrapper-bIIltX.gUhHxl:after',
-  headingIcon: '& .heading--Icon'
+  headingIcon: '& .heading--Icon',
 };
 
 export default {
   styles: {
     body: `
+      overflow: auto;
+
       ${selectors.editPageBtn} {
         display: none;
       }
@@ -200,7 +203,7 @@ export default {
       }
 
       @media (max-width: 560px) {
-        & h1.-bdhje3 {
+        ${selectors.headerTitle} {
           font-size: 48px;
         }
       }

--- a/docs/theme/index.js
+++ b/docs/theme/index.js
@@ -14,7 +14,7 @@ const selectors = {
   mobileLogoArea: '& .Logo__Wrapper-bzwKYh.kYsbLl',
   mobileMenu: '& .Sidebar__Wrapper-dMteFe',
   playgroundWrapper: playgroundSelector,
-  playgroundChildrens: `${playgroundSelector} > div`,
+  playgroundChildren: `${playgroundSelector} > div`,
   headerTitle: '& .H1-ecIwba',
 
   /* Docz default elements (hidden) */
@@ -26,7 +26,7 @@ const selectors = {
   menuBlueTop: '& .Logo__Wrapper-bzwKYh:before',
   menuItemsBorder: '& .MenuLink__Wrapper-bIIltX:after',
   menuSubitemsBorder: '& .MenuLink__Wrapper-bIIltX.gUhHxl:after',
-  headingIcon: '& .heading--Icon',
+  headingIcon: '& .heading--Icon'
 };
 
 export default {
@@ -109,10 +109,15 @@ export default {
       ${selectors.menuArea} {
         background-color: var(--color-space-100);
         border-right: 1px solid var(--color-space-300);
-        width: 280px;
+
+        @media (min-width: 1120px) {
+          width: 320px;
+        }
 
         ${selectors.innerMenuArea} {
-          width: 280px;
+          @media (min-width: 1120px) {
+            width: 320px;
+          }
         }
       }
 
@@ -214,7 +219,7 @@ export default {
         overflow-x: scroll;
       }
 
-      ${selectors.playgroundChildrens} {
+      ${selectors.playgroundChildren} {
         & > * {
           box-sizing: border-box;
           margin: 12px;
@@ -232,6 +237,8 @@ export default {
         }
 
         &.gradient-bg {
+          padding: 16px;
+          margin: -16px;
           background-image: var(--gradient-andromeda);
         }
       }

--- a/docs/theme/index.js
+++ b/docs/theme/index.js
@@ -33,6 +33,7 @@ export default {
   styles: {
     body: `
       overflow: auto;
+      line-height: 1.5;
 
       ${selectors.editPageBtn} {
         display: none;
@@ -108,10 +109,10 @@ export default {
       ${selectors.menuArea} {
         background-color: var(--color-space-100);
         border-right: 1px solid var(--color-space-300);
-        width: 320px;
+        width: 280px;
 
         ${selectors.innerMenuArea} {
-          width: 320px;
+          width: 280px;
         }
       }
 

--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -3,6 +3,7 @@
 
   display: flex;
   position: relative;
+  align-items: center;
 }
 
 .a-checkbox > label {
@@ -39,7 +40,7 @@
 
 .a-checkbox__shape::after {
   position: absolute;
-  top: 7px;
+  top: 5px;
   left: 3px;
   width: 10px;
   height: 6px;
@@ -51,7 +52,7 @@
 }
 
 .a-checkbox--indeterminate > .a-checkbox__shape::after {
-  top: 11px;
+  top: 9px;
   left: 4px;
   width: 8px;
   transform: rotate(-180deg);


### PR DESCRIPTION
# Ticket
[ch15144]

# What

Fix minor layout problems introduced by PR #137 

# Why

The following components look funny:

- checkboxes contents are not vertically aligned;
- the body vertical scrollbar is sometimes not visible;
- page header title is not responsive anymore;
- the ghost input playground background has a padding that cannot be selectively removed;
- line height is smaller in the body selector, which alters layout spacing all over the docs;
- menu width is larger than the original.

# How

Adjust CSS styles here and there.

# Note 

After this, we should test the checkbox components out of the Docz context to see if they're still ok.