### PR TITLE
Improve error state for control input

### DIFF
--- a/docs/inputs.mdx
+++ b/docs/inputs.mdx
@@ -212,7 +212,7 @@ To create the disabled state, add the `a-input--disabled` modifier class on elem
       <i className='a-icon a-icon__input-plus a-icon--size-small' />
     </button>
   </div>
-  <div className='a-input a-input--control a-input--validated'>
+  <div className='a-input a-input--control a-input--invalid'>
     <input
       id='control3'
       type='text'
@@ -222,25 +222,6 @@ To create the disabled state, add the `a-input--disabled` modifier class on elem
       aria-labelledby='controllabel3'
     />
     <label id='controllabel3' htmlFor='control3'>
-      Control input validated (R$)
-    </label>
-    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__decrement'>
-      <i className='a-icon a-icon__input-dash a-icon--size-small' />
-    </button>
-    <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__increment'>
-      <i className='a-icon a-icon__input-plus a-icon--size-small' />
-    </button>
-  </div>
-  <div className='a-input a-input--control a-input--invalid'>
-    <input
-      id='control4'
-      type='text'
-      data-step='100'
-      defaultValue='0,00'
-      placeholder='0,00'
-      aria-labelledby='controllabel4'
-    />
-    <label id='controllabel4' htmlFor='control4'>
       Control input invalid (R$)
     </label>
     <button className='a-btn a-btn--ghost-uranus a-btn--small a-btn--icon a-input--control__decrement'>

--- a/docs/js/inputs.js
+++ b/docs/js/inputs.js
@@ -11,6 +11,25 @@ const currencyMask = createNumberMask({
   decimalSymbol: ','
 });
 
+const pinLabelColors = (inputWrapper, value) => {
+  
+  const input = inputWrapper.querySelector('input');
+  const label = inputWrapper.querySelector('label');
+  value = value || ( input && input.value );
+
+  if(
+    inputWrapper.classList.contains('a-input--invalid') && 
+    value && 
+    !label.classList.contains('a-input--invalid')
+  ) {
+    label.classList.add('a-label--invalid');
+  }
+  
+  if(label && label.classList.contains('a-label--invalid') && !value ) {
+    label.classList.remove("a-label--invalid");
+  }
+}
+
 // Handle floating label
 
 export const initFloatingLabel = () => {
@@ -44,6 +63,12 @@ export const initFloatingLabel = () => {
       currentInput.addEventListener('change', () => {
         verifyValue(currentInput, currentLabel);
       });
+
+      currentInput.addEventListener('input', event => {
+        pinLabelColors(input, event.target.value);
+      });
+
+      pinLabelColors(input);
     });
   });
 };
@@ -150,10 +175,12 @@ export const initControlInputsEvents = () => {
 
       decrementButton.addEventListener('click', () => {
         updateControlInputValue('decrement');
+        pinLabelColors(input);
       });
 
       incrementButton.addEventListener('click', () => {
         updateControlInputValue('increment');
+        pinLabelColors(input);
       });
     });
   });

--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -69,8 +69,8 @@
   color: var(--color-space-100);
 }
 
-.a-input--ghost.a-input--validated::after,
-.a-input--ghost.a-input--invalid::after {
+.a-input--ghost.a-input--validated:not(.a-input--control)::after,
+.a-input--ghost.a-input--invalid:not(.a-input--control)::after {
   background-color: var(--color-space-100);
 }
 
@@ -98,8 +98,20 @@
   top: 13px;
 }
 
-.a-input--control > input:not(:focus) ~ button i {
+.a-input--control > input:not(:focus) ~ button .a-icon {
   background-color: var(--color-moon-500);
+}
+
+.a-input--control.a-input--validated > input ~ .a-btn .a-icon,
+.a-input--control.a-input--validated > input ~ .a-btn:hover .a-icon,
+.a-input--control.a-input--validated > input ~ .a-btn:focus .a-icon {
+  background-color: var(--color-earth-400);
+}
+
+.a-input--control.a-input--invalid > input ~ .a-btn .a-icon,
+.a-input--control.a-input--invalid > input ~ .a-btn:hover .a-icon,
+.a-input--control.a-input--invalid > input ~ .a-btn:focus .a-icon {
+  background-color: var(--color-mars-400);
 }
 
 /* Focus state */
@@ -166,7 +178,8 @@
   border: 1px solid var(--color-mars-500);
 }
 
-.a-input--invalid > input:focus + label {
+.a-input--invalid > input:focus + label,
+.a-input--invalid > .a-label--invalid {
   color: var(--color-mars-500);
 }
 


### PR DESCRIPTION
# What

This __PR__ improves the invalid state for control inputs, remove docs for valid state and fix a bug  related to ghost input valid and invalid state.

[ch15104](https://app.clubhouse.io/magnetis/story/15104/atualizar-estado-inv%C3%A1lido-do-control-input)

# Why

* Design specs for control input component has changed
* To remove a bug introduced previously

# How

* Hide the validation icons only at `a-input--control`
* Add colors to control input buttons on error state
* Remove valid state for input control from docs

# Sample

Bug fix for ghost inputs

|  Before | After  |
|---|---|
| <img width="413" alt="Captura de Tela 2019-07-31 às 16 29 06" src="https://user-images.githubusercontent.com/5252760/62245985-1722f780-b3b9-11e9-98cb-5430c1f4c7d1.png">  |  <img width="414" alt="Captura de Tela 2019-07-31 às 16 28 35" src="https://user-images.githubusercontent.com/5252760/62246010-1f7b3280-b3b9-11e9-86b1-f18d38baa161.png"> |

Improve invalid control input

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/5252760/62247315-f60fd600-b3bb-11e9-95f4-de63587681db.gif)
