### PR TITLE
Add "files" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bugs": {
     "url": "https://github.com/magnetis/astro/issues"
   },
+  "files": [
+    "dist"
+  ],
   "license": "Apache-2.0",
   "main": "dist/astro.css",
   "keywords": [


### PR DESCRIPTION
# What

This PR prevents publishing unnecessary files to npm.

# Why

To keep the module lean and clean and slim and, yeah, that's all.

# How

Using `package.json` "files" property.

