### PR TITLE
Remove font declaration from disabled input

### DIFF
--- a/src/css/inputs.css
+++ b/src/css/inputs.css
@@ -228,7 +228,6 @@
 .a-input--disabled > textarea:disabled + label {
   cursor: not-allowed;
   color: var(--color-moon-300);
-  font: var(--font-secondary);
 }
 
 /* Large size */


### PR DESCRIPTION
# What

Remove font declaration from disabled input label selector.

# Why

Since disabled is just a state, it's not necessary to set the base font again. Furthermore, this overrides other styles undesirably, such as when an input has a floating label *and* is disabled.

# How

Remove the font shorthand from the disabled input label selector.