### PR TITLE
Add step on deploy.js to create 404.html file

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -3,12 +3,17 @@ const gh = require('gh-pages');
 
 const DIST_PATH = '.docz/dist';
 
-fs.copyFile('CNAME', `${DIST_PATH}/CNAME`, (err) => {
+fs.copyFile('CNAME', `${DIST_PATH}/CNAME`, err => {
   if (err) throw err;
   console.log('CNAME file copied to .docz/dist directory');
 });
 
-gh.publish(DIST_PATH, (err) => {
+fs.copyFile(`${DIST_PATH}/index.html`, `${DIST_PATH}/404.html`, err => {
+  if (err) throw err;
+  console.log('index.html file copied as 404.html');
+});
+
+gh.publish(DIST_PATH, err => {
   if (err) {
     console.log('Ops, something went wrong...', err);
   } else {


### PR DESCRIPTION
# What

Fixes sublink problem that ended up returning a 404 error page on github pages.

# Why

It was not possible to go directly to a sublink without first accessing the home page.

# How

Add a new step on `node deploy.js` to copy `index.html` file as `404.html` allowing a redirect to sublinks starting with a hash (#).
