### PR TITLE
Create icon link buttons and add them to the documentation

### DIFF
--- a/docs/buttons.mdx
+++ b/docs/buttons.mdx
@@ -71,14 +71,14 @@ See our [Iconography](https://astro.magnetis.com.br/iconography) to learn how to
     iconlabel
   </button>
   <button className='a-btn a-btn--uranus a-btn--medium a-btn--iconlabel a-btn--iconlabel-right'>
-    iconlabel
+    iconlabel right
     <i className='a-icon a-icon__calendar a-icon--size-medium' />
   </button>
   <button
     className='a-btn a-btn--uranus a-btn--medium a-btn--iconlabel a-btn--iconlabel-right'
     disabled
   >
-    iconlabel
+    iconlabel disabled
     <i className='a-icon a-icon__calendar a-icon--size-medium' />
   </button>
 </Playground>
@@ -93,14 +93,14 @@ Outline iconlabel buttons are commonly used in microinteractions and secondary c
     iconlabel
   </button>
   <button className='a-btn a-btn--outline-uranus a-btn--medium a-btn--iconlabel a-btn--iconlabel-right'>
-    iconlabel
+    iconlabel right
     <i className='a-icon a-icon__calendar a-icon--size-medium' />
   </button>
   <button
     className='a-btn a-btn--outline-uranus a-btn--medium a-btn--iconlabel a-btn--iconlabel-right'
     disabled
   >
-    iconlabel
+    iconlabel disabled
     <i className='a-icon a-icon__calendar a-icon--size-medium' />
   </button>
 </Playground>
@@ -115,14 +115,14 @@ Ghost iconlabel buttons are also used in microinteractions and smaller commands.
     iconlabel
   </button>
   <button className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--iconlabel a-btn--iconlabel-right'>
-    iconlabel
+    iconlabel right
     <i className='a-icon a-icon__calendar a-icon--size-medium' />
   </button>
   <button
     className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--iconlabel a-btn--iconlabel-right'
     disabled
   >
-    iconlabel
+    iconlabel disabled
     <i className='a-icon a-icon__calendar a-icon--size-medium' />
   </button>
 </Playground>
@@ -207,6 +207,40 @@ See our [Iconography](https://astro.magnetis.com.br/iconography) to learn how to
     className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'
     disabled
   >
+    <i className='a-icon a-icon__calendar a-icon--size-medium' />
+  </button>
+</Playground>
+
+## icon link buttons
+
+Icon link buttons can be used for menu items and simple interactions or commands.
+
+To create an icon link button, follow the class structure below. This button does not share base styles with other buttons, so you will not use the generic `a-btn` class; just add the `a-btn--iconlink` class, plus a size modifier. 
+
+Then, if you want the icon to the left of the label, add a `<i>` tag inside the button and before its inner text.
+
+If you want the icon to the right of the label, add the `a-btn--iconlink-right` in addition to the previous settings and place the `<i>` tag inside the button and after its inner text, instead.
+
+See our [Iconography](https://astro.magnetis.com.br/iconography) to learn how to use Astro icons.
+
+<Playground className='gradient-bg'>
+  <button className='a-btn--iconlink a-btn--medium'>
+    <i className='a-icon a-icon__calendar a-icon--size-medium' />
+    icon link
+  </button>
+  <button className='a-btn--iconlink a-btn--medium a-btn--iconlink-bold'>
+    <i className='a-icon a-icon__calendar a-icon--size-medium' />
+    icon link bold
+  </button>
+  <button className='a-btn--iconlink a-btn--medium a-btn--iconlink-right'>
+    icon link right
+    <i className='a-icon a-icon__calendar a-icon--size-medium' />
+  </button>
+  <button
+    className='a-btn--iconlink a-btn--medium a-btn--iconlink-right'
+    disabled
+  >
+    icon link disabled
     <i className='a-icon a-icon__calendar a-icon--size-medium' />
   </button>
 </Playground>

--- a/docs/theme/index.js
+++ b/docs/theme/index.js
@@ -239,7 +239,7 @@ export default {
         &.gradient-bg {
           padding: 16px;
           margin: -16px;
-          background-image: var(--gradient-andromeda);
+          background-image: var(--gradient-black-hole);
         }
       }
     `,

--- a/src/css/buttons.css
+++ b/src/css/buttons.css
@@ -1,5 +1,7 @@
 /* Please don't change the order of the style blocks in this file as it may break the cascade */
 
+/* stylelint-disable no-descending-specificity */
+
 /* Base button styles */
 
 .a-btn {
@@ -172,8 +174,6 @@
   color: var(--color-space-100);
 }
 
-/* stylelint-disable no-descending-specificity */
-
 .a-btn--outline-uranus:disabled,
 .a-btn--outline-venus:disabled,
 .a-btn--outline-earth:disabled,
@@ -187,8 +187,6 @@
   border-color: var(--color-moon-200);
   color: var(--color-moon-200);
 }
-
-/* stylelint-enable */
 
 /* Ghost button base */
 
@@ -267,8 +265,6 @@
   border-color: var(--color-moon-200);
   color: var(--color-mars-600);
 }
-
-/* stylelint-disable no-descending-specificity */
 
 .a-btn--ghost-uranus:disabled,
 .a-btn--ghost-venus:disabled,
@@ -420,7 +416,64 @@
   background-color: var(--color-moon-200);
 }
 
-/* stylelint-enable */
+/* Icon link button */
+
+.a-btn--iconlink {
+  cursor: pointer;
+  display: inline-block;
+  font: var(--font-secondary);
+  color: var(--color-space-100);
+  background-color: transparent;
+  border: none;
+  white-space: nowrap;
+  text-align: center;
+  transition: all 0.3s ease;
+  overflow: hidden;
+}
+
+.a-btn--iconlink:hover:not(:disabled):not(.a-btn--disabled),
+.a-btn--iconlink:focus:not(:disabled):not(.a-btn--disabled) {
+  outline: none;
+  color: var(--color-uranus-500);
+}
+
+.a-btn--iconlink:active:not(:disabled):not(.a-btn--disabled) {
+  color: var(--color-uranus-800);
+}
+
+.a-btn--iconlink:hover:not(:disabled):not(.a-btn--disabled) .a-icon,
+.a-btn--iconlink:focus:not(:disabled):not(.a-btn--disabled) .a-icon {
+  background-color: var(--color-uranus-500);
+}
+
+.a-btn--iconlink:active:not(:disabled):not(.a-btn--disabled) .a-icon {
+  background-color: var(--color-uranus-800);
+}
+
+.a-btn--iconlink .a-icon {
+  background-color: var(--color-space-100);
+  margin: -4px 9px -3px 0;
+  transition: all 0.3s ease;
+}
+
+.a-btn--iconlink-right .a-icon {
+  margin: -4px 0 -3px 9px;
+}
+
+.a-btn--iconlink.a-btn--iconlink-bold {
+  font-weight: 700;
+}
+
+.a-btn--iconlink:disabled,
+.a-btn--iconlink.a-btn--disabled {
+  cursor: not-allowed;
+  color: var(--color-moon-200);
+}
+
+.a-btn--iconlink:disabled .a-icon,
+.a-btn--iconlink.a-btn--disabled .a-icon {
+  background-color: var(--color-moon-200);
+}
 
 /* Button size modifiers */
 


### PR DESCRIPTION
# What

Create new icon link buttons and add them to the documentation.

# Why

This new type of button came with recent design specs - more specifically, the new home.

# How

- Create the styles in buttons.css;
- Add examples to the documentation;
- Change the background of `playground` to a different shade by design request.

# Sample

<img width="782" alt="Screen Shot 2019-08-14 at 17 58 19" src="https://user-images.githubusercontent.com/25252211/63055840-23c94480-bebd-11e9-8482-85c5831b637e.png">
