### PR TITLE
Add toml file to handle single page applications at netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
# What

This __PR__ fixes the problem when trying to access a "sub folder" url from staging at netlify through a link and is shown a 404 page.

# Why

We can't access "sub folders" links from urls outside of docs due to its single page application nature.

# How

* Creating a file to redirect all requests to `/`
