### PR TITLE
Fix font CSS shorthands

### DIFF
--- a/src/css/fonts.css
+++ b/src/css/fonts.css
@@ -7,7 +7,7 @@
   --font-size-5base: calc(var(--font-size-base) * 5);
   --font-size-6base: calc(var(--font-size-base) * 6);
   --font-size-8base: calc(var(--font-size-base) * 8);
-  --font-primary: normal normal 600 normal var(--font-size-2base)/1.5 Poppins, sans-serif;
-  --font-secondary: normal normal 400 normal var(--font-size-2base)/1.5 Lato, sans-serif;
+  --font-primary: normal normal 600 var(--font-size-2base)/1.5 Poppins, sans-serif;
+  --font-secondary: normal normal 400 var(--font-size-2base)/1.5 Lato, sans-serif;
   --font-color: var(--color-moon-900);
 }


### PR DESCRIPTION
# What

This PR removes an extra parameter in the font shorthands.

# Why

When we tested new Magnetis pages, we found that Microsoft Edge didn't display the fonts correctly.

Unlike other ~decent~ browsers, Edge doesn't handle/autocorrect extra parameters in the font shorthand.

<img width="1245" alt="Captura de Tela 2019-09-13 às 15 47 44" src="https://user-images.githubusercontent.com/1002072/64892379-a410d000-d64a-11e9-9912-8033973f4238.png">

# How

Remove extra `normal` parameter from font shorthands.

# Sample

| Before | After |
| --- | --- |
| <img width="890" alt="Captura de Tela 2019-09-13 às 16 55 53" src="https://user-images.githubusercontent.com/1002072/64892508-f5b95a80-d64a-11e9-8f80-53fc078e045f.png"> | <img width="870" alt="Captura de Tela 2019-09-13 às 16 54 19" src="https://user-images.githubusercontent.com/1002072/64892520-fe119580-d64a-11e9-81aa-420653e52967.png"> |

# Refs

* [Clubhouse's card](https://app.clubhouse.io/magnetis/story/19038/corrigir-fontes-para-as-páginas-abertas-no-astro) [ch19038]
* [Font shorthand's ref](https://css-tricks.com/snippets/css/font-shorthand/)