### PR TITLE
Add more z-index variables

### DIFF
--- a/src/css/z-index.css
+++ b/src/css/z-index.css
@@ -3,4 +3,10 @@
   --z-index-2: 20;
   --z-index-3: 30;
   --z-index-4: 40;
+  --z-index-5: 50;
+  --z-index-6: 60;
+  --z-index-7: 70;
+  --z-index-8: 80;
+  --z-index-9: 90;
+  --z-index-10: 100;
 }


### PR DESCRIPTION
# What

This __PR__ adds more z-index variables.

# Why

Because we needed to use a higher z-index on case where we have various elements with deferents z-indexes.