### PR TITLE
Remove code sanbox link

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -27,5 +27,6 @@ export default {
     'iconography',
     'inputs',
     'typography'
-  ]
+  ],
+  codeSandbox: false
 };


### PR DESCRIPTION
# What

This __PR__ removes the link icon for code sanbox

# Why

Due to the get request for code sanbox api being to large, we have an error when we try to use this functionality. This is a docz problem where they should use a post request instead of get. We'll enable this in the future if any fix is published.

# How

* Change doczrc config

# Sample

Before

<img width="885" alt="Captura de Tela 2019-10-09 às 16 25 15" src="https://user-images.githubusercontent.com/5252760/66513419-71bf8a80-eab1-11e9-9af8-65b9ee385989.png">


After

<img width="888" alt="Captura de Tela 2019-10-09 às 16 24 53" src="https://user-images.githubusercontent.com/5252760/66513411-6d936d00-eab1-11e9-82be-9a6679b137b1.png">

