### PR TITLE
Adjust spacing in home screen

### DIFF
--- a/docs/components/ManifestoCards.jsx
+++ b/docs/components/ManifestoCards.jsx
@@ -4,7 +4,7 @@ import open from '../img/open.png';
 import accessible from '../img/accessible.png';
 
 export default () => (
-  <div className='cards-box'>
+  <div className='cards-box cards-box--spaced'>
     <div>
       <div className="cards-box__image">
         <img src={atomic} className="atomic-illustration" alt="" />

--- a/docs/css/home.css
+++ b/docs/css/home.css
@@ -4,6 +4,9 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+}
+
+.cards-box--spaced {
   margin-top: 121px;
 }
 


### PR DESCRIPTION
# What

The space below "get started" title in home screen got too big after inserting the illustrations in home screen. In this PR it was fixed.

# Why

To improve astro home page design

# How

The problem was css classes conflicting and the solution was create a specific rule to attend the illustration spacing.

# Sample

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/42543262/67424273-355d5580-f5ac-11e9-9de2-36a6fac89051.png">

