### PR TITLE
Table styles

### DIFF
--- a/docs/tables.mdx
+++ b/docs/tables.mdx
@@ -1,0 +1,106 @@
+---
+name: tables
+---
+
+import '../src/index.css';
+import { Playground } from 'docz';
+
+# tables
+
+### standard table styles
+
+To apply the standard styles to a `table` element, add the `a-table` class. No
+modifiers are available or required.
+
+Be aware that typgraphy styles are not applied by default and you should style
+the `th` and `td` elements as necessary for your table.
+
+Buttons using the `a-btn` (and related modifiers) that are placed inside the last
+`td` of each row will be properly aligned together as the set of actions available
+for that row.
+
+<Playground>
+  <table className='a-table'>
+    <thead>
+      <tr>
+        <th className='a-text--medium' scope='col'>rank</th>
+        <th className='a-text--medium' scope='col'>title</th>
+        <th className='a-text--medium' scope='col'>distributor</th>
+        <th className='a-text--medium' scope='col' colspan='2'>worldwide gross</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td className='a-text--secondary-medium'><strong>1</strong></td>
+        <td className='a-text--secondary-medium'>Avengers: Infinity War</td>
+        <td className='a-text--secondary-medium'>Disney</td>
+        <td className='a-text--secondary-medium'>$2,048,359,754</td>
+        <td>
+          <button title='delete' aria-label='delete' className='a-btn a-btn--ghost-mars a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--trash a-icon--size-medium' />
+          </button>
+          <a  title='edit' aria-label='edit' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--pencil a-icon--size-medium' />
+          </a>
+          <a  title='view' aria-label='view' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--circle-right a-icon--size-medium' />
+          </a>
+        </td>
+      </tr>
+
+      <tr>
+        <td className='a-text--secondary-medium'><strong>2</strong></td>
+        <td className='a-text--secondary-medium'>Black Panther</td>
+        <td className='a-text--secondary-medium'>Disney</td>
+        <td className='a-text--secondary-medium'>$1,346,913,161</td>
+        <td>
+          <button title='delete' aria-label='delete' className='a-btn a-btn--ghost-mars a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--trash a-icon--size-medium' />
+          </button>
+          <a  title='edit' aria-label='edit' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--pencil a-icon--size-medium' />
+          </a>
+          <a  title='view' aria-label='view' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--circle-right a-icon--size-medium' />
+          </a>
+        </td>
+      </tr>
+
+      <tr>
+        <td className='a-text--secondary-medium'><strong>3</strong></td>
+        <td className='a-text--secondary-medium'>Jurassic World: Fallen Kingdom</td>
+        <td className='a-text--secondary-medium'>Universal</td>
+        <td className='a-text--secondary-medium'>$1,309,484,461</td>
+        <td>
+          <button title='delete' aria-label='delete' className='a-btn a-btn--ghost-mars a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--trash a-icon--size-medium' />
+          </button>
+          <a  title='edit' aria-label='edit' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--pencil a-icon--size-medium' />
+          </a>
+          <a  title='view' aria-label='view' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--circle-right a-icon--size-medium' />
+          </a>
+        </td>
+      </tr>
+
+      <tr>
+        <td className='a-text--secondary-medium'><strong>4</strong></td>
+        <td className='a-text--secondary-medium'>Incredibles 2</td>
+        <td className='a-text--secondary-medium'>Disney</td>
+        <td className='a-text--secondary-medium'>$1,242,805,359</td>
+        <td>
+          <button title='delete' aria-label='delete' className='a-btn a-btn--ghost-mars a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--trash a-icon--size-medium' />
+          </button>
+          <a  title='edit' aria-label='edit' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--pencil a-icon--size-medium' />
+          </a>
+          <a  title='view' aria-label='view' className='a-btn a-btn--ghost-uranus a-btn--medium a-btn--icon'>
+            <i className='a-icon a-icon--circle-right a-icon--size-medium' />
+          </a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Playground>

--- a/docs/tables.mdx
+++ b/docs/tables.mdx
@@ -12,7 +12,7 @@ import { Playground } from 'docz';
 To apply the standard styles to a `table` element, add the `a-table` class. No
 modifiers are available or required.
 
-Be aware that typgraphy styles are not applied by default and you should style
+Be aware that typography styles are not applied by default and you should style
 the `th` and `td` elements as necessary for your table.
 
 Buttons using the `a-btn` (and related modifiers) that are placed inside the last

--- a/src/css/tables.css
+++ b/src/css/tables.css
@@ -1,0 +1,53 @@
+:root {
+  --table-odd-row-color: var(--color-moon-100);
+  --table-header-color: var(--color-moon-500);
+  --table-row-border-radius: 4px;
+}
+
+.a-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.a-table th {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  color: var(--table-header-color);
+  text-align: left;
+}
+
+.a-table td {
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+
+.a-table td:first-child {
+  border-top-left-radius: var(--table-row-border-radius);
+  border-bottom-left-radius: var(--table-row-border-radius);
+}
+
+.a-table td:last-child {
+  /*
+  Styles for aligning action links/buttons on the last cell of each row,
+  can be replaced by implemeting a `button-group` wrapper por multiple buttons.
+  */
+  display: flex;
+  text-align: right;
+  justify-content: flex-end;
+  border-top-right-radius: var(--table-row-border-radius);
+  border-bottom-right-radius: var(--table-row-border-radius);
+}
+
+.a-table td:first-child,
+.a-table th:first-child {
+  padding-left: 32px;
+}
+
+.a-table td:last-child,
+.a-table th:last-child {
+  padding-right: 32px;
+}
+
+.a-table tr:nth-child(odd) td {
+  background-color: var(--table-odd-row-color);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -12,5 +12,6 @@
 @import './css/toggle.css';
 @import './css/inputs.css';
 @import './css/slider.css';
+@import './css/tables.css';
 @import './css/tabs.css';
 @import './css/web-fonts.css';


### PR DESCRIPTION
# What

This brings the table styles from recent app work into astro to pave the way as a set of defaults for any purpose tables 

## Things to do (please pitch in!)

* [x] Review spacing rules to keep consistency with existing components, as all the `padding-` settings came from one single design, I don't know if we have strict rules for this.
* [x] Review the purpose of `a-table__row-actions`
* [x] Write an actual documentation to go along with the `<Playground />` example
* ~~Should we add any responsive styles right now? [There are a handful of strategies for this problem](https://css-tricks.com/responsive-data-table-roundup/), but I don't know if we should have a default approach right now~~

# Sample

<img width="846" alt="Screen Shot 2019-11-08 at 16 22 05" src="https://user-images.githubusercontent.com/80978/68504691-4bbe0f00-0244-11ea-9fa5-5689ea23227b.png">
