### PR TITLE
Inactive table row style

### DIFF
--- a/docs/tables.mdx
+++ b/docs/tables.mdx
@@ -15,6 +15,9 @@ modifiers are available or required.
 Be aware that typography styles are not applied by default and you should style
 the `th` and `td` elements as necessary for your table.
 
+To represent an inactive entry in the table add the `a-table__row--inactive` class
+to the corresponding table row.
+
 Buttons using the `a-btn` (and related modifiers) that are placed inside the last
 `td` of each row will be properly aligned together as the set of actions available
 for that row.
@@ -84,9 +87,9 @@ for that row.
         </td>
       </tr>
 
-      <tr>
+      <tr className='a-table__row--inactive'>
         <td className='a-text--secondary-medium'><strong>4</strong></td>
-        <td className='a-text--secondary-medium'>Incredibles 2</td>
+        <td className='a-text--secondary-medium'>Incredibles 2 (inactive)</td>
         <td className='a-text--secondary-medium'>Disney</td>
         <td className='a-text--secondary-medium'>$1,242,805,359</td>
         <td>

--- a/src/css/tables.css
+++ b/src/css/tables.css
@@ -1,6 +1,7 @@
 :root {
   --table-odd-row-color: var(--color-moon-100);
   --table-header-color: var(--color-moon-500);
+  --table-row-inactive-color: var(--color-moon-300);
   --table-row-border-radius: 4px;
 }
 
@@ -50,4 +51,8 @@
 
 .a-table tr:nth-child(odd) td {
   background-color: var(--table-odd-row-color);
+}
+
+.a-table tr.a-table__row--inactive td {
+  color: var(--table-row-inactive-color);
 }


### PR DESCRIPTION
# What

Hi there 👋 

Now it's possible to add the `a-table__row--inactive` modifier to represent an inactive table row in a table. This modifier class changes the default font color to a greyish one.

# Sample

<img width="854" alt="Astro 2019-12-09 18-32-03" src="https://user-images.githubusercontent.com/4418131/70474928-3beb5200-1ab2-11ea-9bba-0b6564d68187.png">

