### PR TITLE
Adjust checkbox positioning

### DIFF
--- a/src/css/checkbox.css
+++ b/src/css/checkbox.css
@@ -3,7 +3,6 @@
 }
 
 .a-checkbox {
-  position: relative;
   display: flex;
   align-items: center;
 }
@@ -25,10 +24,14 @@
   z-index: var(--z-index-1);
   width: var(--checkbox-square-size);
   height: var(--checkbox-square-size);
-  margin: 4px 0;
   cursor: pointer;
   opacity: 0;
   order: 1;
+}
+
+.a-checkbox__shape {
+  position: relative;
+  line-height: 0;
 }
 
 .a-checkbox__shape::before {
@@ -42,7 +45,7 @@
 
 .a-checkbox__shape::after {
   position: absolute;
-  top: 5px;
+  top: 4px;
   left: 3px;
   width: 10px;
   height: 6px;
@@ -54,7 +57,7 @@
 }
 
 .a-checkbox--indeterminate > .a-checkbox__shape::after {
-  top: 9px;
+  top: 8px;
   left: 4px;
   width: 8px;
   border-left: 0;


### PR DESCRIPTION
# What

Adjusts the positioning of checkbox

# Why

There's a bug when the label is larger than 1 line, also the checkbox is not perfect centered relative to the label

Before | After
------------ | -------------
![Astro](https://user-images.githubusercontent.com/3473678/72008967-ac150100-3233-11ea-9256-566c0abeb818.png) | ![Astro](https://user-images.githubusercontent.com/3473678/72009023-cf3fb080-3233-11ea-9821-d66ac890003a.png)